### PR TITLE
feat(client,extension): improve i18n moment locale and page context handling

### DIFF
--- a/app/client/src/components/SmartMoment.tsx
+++ b/app/client/src/components/SmartMoment.tsx
@@ -1,5 +1,6 @@
 import moment from "moment";
 import Tooltip from "@mui/material/Tooltip";
+import { useTranslation } from "react-i18next";
 
 type SmartMomentProps = {
   dt: string | Date | number;
@@ -7,21 +8,25 @@ type SmartMomentProps = {
 }
 
 const SmartMoment = ({dt, timeTypeLabel}: SmartMomentProps) => {
+  const { i18n } = useTranslation();
+  const momentLocale = i18n.language?.startsWith('zh') ? 'zh-cn' : 'en';
+  const localized = moment(dt).locale(momentLocale);
+
   function getMoment() {
     let text = "";
-    if (moment(dt).isAfter(moment().add(-1, "d"))) {
-      text = moment(dt).fromNow(true);
-    } else if (moment(dt).isBefore(moment().startOf("year"))) {
-      text = moment(dt).format('ll');
+    if (localized.isAfter(moment().add(-1, "d"))) {
+      text = localized.fromNow(true);
+    } else if (localized.isBefore(moment().startOf("year"))) {
+      text = localized.format('ll');
     } else {
-      text = moment(dt).format('M-D HH:mm');
+      text = localized.format('M-D HH:mm');
     }
     return text;
   }
 
   const tooltipText = timeTypeLabel
-    ? `${timeTypeLabel}: ${moment(dt).format('a h:mm ll')}`
-    : moment(dt).format('a h:mm ll');
+    ? `${timeTypeLabel}: ${localized.format('a h:mm ll')}`
+    : localized.format('a h:mm ll');
 
   return (
     <Tooltip title={tooltipText} arrow>

--- a/app/client/src/i18n/index.ts
+++ b/app/client/src/i18n/index.ts
@@ -1,6 +1,8 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import moment from 'moment';
+import 'moment/locale/zh-cn';
 
 import enCommon from './locales/en/common.json';
 import enNavigation from './locales/en/navigation.json';
@@ -59,5 +61,12 @@ i18n
       caches: ['localStorage'],
     },
   });
+
+const toMomentLocale = (lng?: string) => (lng?.startsWith('zh') ? 'zh-cn' : 'en');
+
+moment.locale(toMomentLocale(i18n.language));
+i18n.on('languageChanged', (lng) => {
+  moment.locale(toMomentLocale(lng));
+});
 
 export default i18n;

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -6,8 +6,6 @@ import reportWebVitals from "./reportWebVitals";
 import "./styles/globals.css";
 import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
 import {ReactQueryDevtools} from "@tanstack/react-query-devtools";
-import moment from "moment";
-import 'moment/locale/zh-cn'
 import {SnackbarProvider} from "notistack";
 
 const queryClient = new QueryClient({
@@ -21,7 +19,6 @@ const queryClient = new QueryClient({
     }
   },
 });
-moment.locale('zh-cn');
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement

--- a/app/extension/src/sidepanel/SidepanelApp.tsx
+++ b/app/extension/src/sidepanel/SidepanelApp.tsx
@@ -212,9 +212,11 @@ async function createCurrentPageContextPart(): Promise<ChatPart> {
     throw new Error("Could not extract page content.");
   }
 
+  const tabTitle = tab.title || page.title || "Current tab";
+  const articleTitle = page.title;
   const pageContext: ParsedPageContext = {
     ...page,
-    title: page.title || tab.title || "Current tab",
+    title: articleTitle || tabTitle,
     url: page.url || tab.url,
     faviconUrl: page.faviconUrl || tab.favIconUrl,
   };
@@ -222,7 +224,8 @@ async function createCurrentPageContextPart(): Promise<ChatPart> {
   return {
     id: generateId(),
     type: "page-context",
-    title: pageContext.title,
+    title: tabTitle,
+    articleTitle,
     url: pageContext.url,
     faviconUrl: pageContext.faviconUrl,
     content: buildPageContextMarkdown(pageContext),
@@ -862,44 +865,14 @@ const ComposerContextBar: FC<ComposerContextBarProps> = ({
   onDetachContext,
 }) => {
   const label = contextError || tabContext?.title || "Current tab";
-
-  return (
-    <div
-      className={[
-        "mr-3 flex min-w-0 max-w-[min(360px,calc(100%-120px))] items-center gap-1.5 rounded-lg bg-[#fffaf4]/80 px-1.5 py-1 pr-3 shadow-[0_6px_18px_rgba(64,48,31,0.06)] transition-colors",
-        contextAttached
-          ? "border border-solid border-[#d8cfbf]"
-          : "border border-dashed border-[#d8b18d]",
-      ].join(" ")}
-    >
-      <div className="flex h-6 w-6 shrink-0 items-center justify-center">
-        {contextAttached ? (
-          <button
-            type="button"
-            aria-label="Remove attached context"
-            title="Remove attached context"
-            className="flex h-6 w-6 items-center justify-center rounded-md text-[#75695b] transition-colors hover:bg-[#f1e8da] hover:text-[#2f261f]"
-            onClick={onDetachContext}
-          >
-            <X className="size-3.5" />
-          </button>
-        ) : (
-          <button
-            type="button"
-            aria-label="Add current tab context"
-            title="Add current tab context"
-            disabled={contextLoading || !tabContext}
-            className="flex h-6 w-6 items-center justify-center rounded-md text-[#8a7e70] transition-colors hover:bg-[#f1e8da] hover:text-[#2f261f] disabled:cursor-not-allowed disabled:opacity-60"
-            onClick={onAttachContext}
-          >
-            {contextLoading ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              <Plus className="size-3.5" />
-            )}
-          </button>
-        )}
-      </div>
+  const containerClassName = [
+    "mr-3 flex min-w-0 max-w-[min(360px,calc(100%-120px))] items-center gap-1.5 rounded-lg bg-[#fffaf4]/80 px-1.5 py-1 pr-3 shadow-[0_6px_18px_rgba(64,48,31,0.06)] transition-colors",
+    contextAttached
+      ? "border border-solid border-[#d8cfbf]"
+      : "border border-dashed border-[#d8b18d]",
+  ].join(" ");
+  const tabContextDetails = (
+    <>
       <TabFavicon
         faviconUrl={tabContext?.faviconUrl}
         muted={!contextAttached}
@@ -917,6 +890,48 @@ const ComposerContextBar: FC<ComposerContextBarProps> = ({
       >
         {label}
       </span>
+    </>
+  );
+
+  if (!contextAttached) {
+    return (
+      <button
+        type="button"
+        aria-label="Add current tab context"
+        title="Add current tab context"
+        disabled={contextLoading || !tabContext}
+        className={[
+          containerClassName,
+          "cursor-pointer text-left hover:bg-[#fff5e8] disabled:cursor-not-allowed disabled:opacity-70",
+        ].join(" ")}
+        onClick={onAttachContext}
+      >
+        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[#8a7e70]">
+          {contextLoading ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Plus className="size-3.5" />
+          )}
+        </div>
+        {tabContextDetails}
+      </button>
+    );
+  }
+
+  return (
+    <div className={containerClassName}>
+      <div className="flex h-6 w-6 shrink-0 items-center justify-center">
+        <button
+          type="button"
+          aria-label="Remove attached context"
+          title="Remove attached context"
+          className="flex h-6 w-6 items-center justify-center rounded-md text-[#75695b] transition-colors hover:bg-[#f1e8da] hover:text-[#2f261f]"
+          onClick={onDetachContext}
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+      {tabContextDetails}
     </div>
   );
 };

--- a/app/extension/src/sidepanel/types.ts
+++ b/app/extension/src/sidepanel/types.ts
@@ -27,6 +27,7 @@ export interface ChatPart {
   id?: string;
   text?: string;
   title?: string;
+  articleTitle?: string;
   url?: string;
   faviconUrl?: string;
   content?: string;

--- a/app/extension/src/sidepanel/useHuntlyChat.ts
+++ b/app/extension/src/sidepanel/useHuntlyChat.ts
@@ -188,7 +188,9 @@ function safeStringify(value: unknown): string {
 
 function formatPageContextForModel(part: ChatPart): string {
   const metadata: string[] = [];
-  if (part.title) metadata.push(`Title: ${part.title}`);
+  if (part.title) metadata.push(`Original page title: ${part.title}`);
+  if (part.articleTitle)
+    metadata.push(`Parsed article title: ${part.articleTitle}`);
   if (part.url) metadata.push(`URL: ${part.url}`);
 
   return [


### PR DESCRIPTION
## Summary

- **Client – moment locale**: Moved `moment.locale()` initialization into `app/client/src/i18n/index.ts` and wired it to i18next's `languageChanged` event. This removes the hardcoded `zh-cn` from `index.tsx` and makes locale changes dynamic.
- **Client – SmartMoment**: Component now reads the active i18n language and creates a locale-aware `moment` instance, so timestamps render correctly in both Chinese and English UIs.
- **Extension – page context titles**: `createCurrentPageContextPart` now tracks `tabTitle` (browser tab title) and `articleTitle` (parsed article title) separately. Both are surfaced to the LLM via `formatPageContextForModel` as `Original page title` and `Parsed article title`.
- **Extension – ComposerContextBar UX**: When no context is attached, the entire pill container is now a single `<button>` element, making the click target much larger and more intuitive instead of the previous small `+` icon button.

## Verification

- Checked that `moment/locale/zh-cn` is still imported (moved from `index.tsx` to `i18n/index.ts`).
- No new dependencies added; no build artifacts included.