### PR TITLE
feat(extension): integrate MCP tool loading and context menu image/selection support

### DIFF
--- a/app/extension/package.json
+++ b/app/extension/package.json
@@ -24,6 +24,7 @@
     "@ai-sdk/deepseek": "^2.0.24",
     "@ai-sdk/google": "^3.0.43",
     "@ai-sdk/groq": "^3.0.29",
+    "@ai-sdk/mcp": "^1.0.36",
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/react": "^3.0.170",
     "@emotion/react": "^11.10.6",

--- a/app/extension/src/background.ts
+++ b/app/extension/src/background.ts
@@ -42,6 +42,27 @@ const vercelAIAbortControllers = new Map<string, AbortController>();
 // Badge management: cache to avoid redundant API calls
 // Maps tabId -> url to track which URL was last checked for each tab
 const badgeCache = new Map<number, string>();
+type PendingSelectionPageContext = Pick<
+  PageModel,
+  "title" | "content" | "url" | "faviconUrl" | "description" | "author" | "siteName"
+>;
+type PendingSidepanelContextCommand = {
+  id: string;
+} & (
+  | {
+      kind: "image";
+      source: string;
+    }
+  | {
+      kind: "page-context";
+    }
+  | {
+      kind: "selection";
+      page: PendingSelectionPageContext;
+    }
+);
+const pendingSidepanelContextCommands =
+  new Map<number, PendingSidepanelContextCommand[]>();
 const SAVED_BADGE_TEXT = "✓";
 const SAVED_BADGE_BG = "#15803D";
 const AI_MAX_OUTPUT_TOKENS = 20000;
@@ -95,6 +116,19 @@ async function blobToDataUrl(blob: Blob): Promise<string> {
   const base64 = arrayBufferToBase64(buffer);
 
   return `data:${contentType};base64,${base64}`;
+}
+
+function sendMessageToTab<T = any>(tabId: number, message: unknown): Promise<T> {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, message, (response) => {
+      const error = chrome.runtime.lastError;
+      if (error) {
+        reject(new Error(error.message));
+        return;
+      }
+      resolve(response as T);
+    });
+  });
 }
 
 /**
@@ -166,6 +200,23 @@ function cancelVercelAITask(taskId: string): boolean {
     return true;
   }
   return false;
+}
+
+function enqueuePendingSidepanelContextCommand(
+  windowId: number,
+  command: PendingSidepanelContextCommand
+): void {
+  const queue = pendingSidepanelContextCommands.get(windowId) || [];
+  queue.push(command);
+  pendingSidepanelContextCommands.set(windowId, queue);
+}
+
+function consumePendingSidepanelContextCommands(
+  windowId: number
+): PendingSidepanelContextCommand[] {
+  const queued = pendingSidepanelContextCommands.get(windowId) || [];
+  pendingSidepanelContextCommands.delete(windowId);
+  return queued;
 }
 
 function startProcessingWithShortcuts(
@@ -581,7 +632,22 @@ export function initBackground(): void {
         chrome.tabs.create({ url });
       }
     } else if ((msg as any).type === "open_side_panel") {
-      openSidePanelForContextMenuClick(sender.tab);
+      void openSidePanelForContextMenuClick(sender.tab);
+    } else if ((msg as any).type === "consume_pending_sidepanel_context_commands") {
+      const windowId = msg.payload?.windowId;
+      if (typeof windowId !== "number") {
+        sendResponse({
+          success: false,
+          error: "Invalid window id for pending sidepanel context commands.",
+        });
+        return;
+      }
+
+      sendResponse({
+        success: true,
+        commands: consumePendingSidepanelContextCommands(windowId),
+      });
+      return;
     } else if ((msg as any).type === "fetch_image") {
       const imageUrl = msg.payload?.url;
       if (!imageUrl) {
@@ -830,14 +896,28 @@ function refreshBadgeForActiveTab() {
 const CONTEXT_MENU_HUNTLY_ROOT = "huntly_root";
 const CONTEXT_MENU_READING_MODE_PAGE = "huntly_reading_mode_page";
 const CONTEXT_MENU_SIDE_PANEL_PAGE = "huntly_side_panel_page";
+const CONTEXT_MENU_SIDE_PANEL_IMAGE = "huntly_side_panel_image";
 const CONTEXT_MENU_READING_MODE_ACTION = "huntly_reading_mode_action";
 const CONTEXT_MENU_SIDE_PANEL_ACTION = "huntly_side_panel_action";
-const CONTEXT_MENU_PAGE_CONTEXTS = ["page", "selection"];
-const CONTEXT_MENU_ACTION_CONTEXTS = ["action"];
+const CONTEXT_MENU_PAGE_CONTEXTS: chrome.contextMenus.ContextType[] = [
+  "page",
+  "selection",
+];
+const CONTEXT_MENU_IMAGE_CONTEXTS: chrome.contextMenus.ContextType[] = [
+  "image",
+];
+const CONTEXT_MENU_ACTION_CONTEXTS: chrome.contextMenus.ContextType[] = [
+  "action",
+];
+const CONTEXT_MENU_PAGE_AND_IMAGE_CONTEXTS: chrome.contextMenus.ContextType[] = [
+  ...CONTEXT_MENU_PAGE_CONTEXTS,
+  ...CONTEXT_MENU_IMAGE_CONTEXTS,
+];
 
 const HUNTLY_MENU_TITLE = isDebugging ? "Huntly [DEV]" : "Huntly";
 const READING_MODE_TITLE = "Reading Mode";
 const SIDE_PANEL_TITLE = "Chat";
+const SIDE_PANEL_SEND_TITLE = "Send to Chat";
 
 function createContextMenuItem(
   properties: chrome.contextMenus.CreateProperties
@@ -858,21 +938,28 @@ function setupContextMenus() {
     createContextMenuItem({
       id: CONTEXT_MENU_HUNTLY_ROOT,
       title: HUNTLY_MENU_TITLE,
-      contexts: CONTEXT_MENU_PAGE_CONTEXTS,
+      contexts: CONTEXT_MENU_PAGE_AND_IMAGE_CONTEXTS,
     });
 
     createContextMenuItem({
       id: CONTEXT_MENU_READING_MODE_PAGE,
       parentId: CONTEXT_MENU_HUNTLY_ROOT,
       title: READING_MODE_TITLE,
-      contexts: CONTEXT_MENU_PAGE_CONTEXTS,
+      contexts: CONTEXT_MENU_PAGE_AND_IMAGE_CONTEXTS,
     });
 
     createContextMenuItem({
       id: CONTEXT_MENU_SIDE_PANEL_PAGE,
       parentId: CONTEXT_MENU_HUNTLY_ROOT,
       title: SIDE_PANEL_TITLE,
-      contexts: CONTEXT_MENU_PAGE_CONTEXTS,
+      contexts: CONTEXT_MENU_PAGE_AND_IMAGE_CONTEXTS,
+    });
+
+    createContextMenuItem({
+      id: CONTEXT_MENU_SIDE_PANEL_IMAGE,
+      parentId: CONTEXT_MENU_HUNTLY_ROOT,
+      title: SIDE_PANEL_SEND_TITLE,
+      contexts: CONTEXT_MENU_IMAGE_CONTEXTS,
     });
 
     createContextMenuItem({
@@ -904,20 +991,33 @@ async function resolveContextMenuTab(
   return getCurrentActiveTab();
 }
 
-function openSidePanelForContextMenuClick(tab?: chrome.tabs.Tab): void {
+function openSidePanelForContextMenuClick(tab?: chrome.tabs.Tab): boolean {
   const sidePanelApi = (chrome as any).sidePanel;
   if (!sidePanelApi?.open) {
-    return;
+    return false;
   }
 
   if (typeof tab?.windowId !== "number") {
-    log("Failed to open side panel: missing windowId from context menu tab");
-    return;
+    log("Failed to open side panel: missing window id");
+    return false;
+  }
+
+  if (typeof tab.id === "number" && typeof sidePanelApi.setOptions === "function") {
+    void sidePanelApi
+      .setOptions({
+        tabId: tab.id,
+        path: "sidepanel.html",
+        enabled: true,
+      })
+      .catch((error: unknown) => {
+        log("Failed to configure side panel:", error);
+      });
   }
 
   void sidePanelApi.open({ windowId: tab.windowId }).catch((error: unknown) => {
     log("Failed to open side panel:", error);
   });
+  return true;
 }
 
 function isReadingModeMenuItem(menuItemId: string | number): boolean {
@@ -932,6 +1032,121 @@ function isSidePanelMenuItem(menuItemId: string | number): boolean {
     menuItemId === CONTEXT_MENU_SIDE_PANEL_PAGE ||
     menuItemId === CONTEXT_MENU_SIDE_PANEL_ACTION
   );
+}
+
+async function handleImageSidePanelContextMenuClick(
+  info: chrome.contextMenus.OnClickData,
+  tab?: chrome.tabs.Tab
+): Promise<void> {
+  if (!info.srcUrl) return;
+
+  const openedFromContextMenu = openSidePanelForContextMenuClick(tab);
+
+  const targetTab = tab?.id ? tab : await resolveContextMenuTab(tab);
+  if (!targetTab || typeof targetTab.windowId !== "number") return;
+
+  const command: PendingSidepanelContextCommand = {
+    id: crypto.randomUUID(),
+    kind: "image",
+    source: info.srcUrl,
+  };
+
+  if (!openedFromContextMenu && !openSidePanelForContextMenuClick(targetTab)) {
+    enqueuePendingSidepanelContextCommand(targetTab.windowId, command);
+    return;
+  }
+
+  try {
+    const response = await chrome.runtime.sendMessage({
+      type: "sidepanel_context_menu_command",
+      payload: {
+        command,
+        windowId: targetTab.windowId,
+      },
+    });
+
+    if (response?.success && response.commandId === command.id) {
+      return;
+    }
+  } catch (error) {
+    log("Deferred sidepanel image attachment until panel is ready", error);
+  }
+
+  enqueuePendingSidepanelContextCommand(targetTab.windowId, command);
+}
+
+async function handlePageSidePanelContextMenuClick(
+  info: chrome.contextMenus.OnClickData,
+  tab?: chrome.tabs.Tab
+): Promise<void> {
+  const targetTab = await resolveContextMenuTab(tab);
+  if (
+    !targetTab?.id ||
+    typeof targetTab.id !== "number" ||
+    typeof targetTab.windowId !== "number"
+  ) {
+    return;
+  }
+
+  let command: PendingSidepanelContextCommand;
+  if (info.selectionText?.trim()) {
+    try {
+      const response = await sendMessageToTab<{ page?: PageModel | null }>(
+        targetTab.id,
+        { type: "get_selection" }
+      );
+      const page = response?.page;
+      if (!page?.content) {
+        return;
+      }
+
+      command = {
+        id: crypto.randomUUID(),
+        kind: "selection",
+        page: {
+          title: page.title,
+          content: page.content,
+          url: page.url,
+          faviconUrl: page.faviconUrl,
+          description: page.description,
+          author: page.author,
+          siteName: page.siteName,
+        },
+      };
+    } catch (error) {
+      log("Failed to capture page selection for chat", error);
+      return;
+    }
+  } else {
+    command = {
+      id: crypto.randomUUID(),
+      kind: "page-context",
+    };
+  }
+
+  const opened = await openSidePanelForContextMenuClick(targetTab);
+  if (!opened) {
+    enqueuePendingSidepanelContextCommand(targetTab.windowId, command);
+    return;
+  }
+
+  try {
+    const response = await chrome.runtime.sendMessage({
+      type: "sidepanel_context_menu_command",
+      payload: {
+        command,
+        windowId: targetTab.windowId,
+      },
+    });
+
+    if (response?.success && response.commandId === command.id) {
+      return;
+    }
+  } catch (error) {
+    log("Deferred sidepanel page context command until panel is ready", error);
+  }
+
+  enqueuePendingSidepanelContextCommand(targetTab.windowId, command);
 }
 
 async function handleReadingModeContextMenuClick(
@@ -1014,12 +1229,21 @@ function registerBackgroundUiListeners(): void {
     badgeCache.delete(tabId);
   });
 
+  chrome.windows.onRemoved.addListener((windowId) => {
+    pendingSidepanelContextCommands.delete(windowId);
+  });
+
   chrome.runtime.onInstalled.addListener(setupContextMenus);
   chrome.runtime.onStartup.addListener(setupContextMenus);
 
   chrome.contextMenus.onClicked.addListener((info, tab) => {
+    if (info.menuItemId === CONTEXT_MENU_SIDE_PANEL_IMAGE) {
+      void handleImageSidePanelContextMenuClick(info, tab);
+      return;
+    }
+
     if (isSidePanelMenuItem(info.menuItemId)) {
-      openSidePanelForContextMenuClick(tab);
+      void openSidePanelForContextMenuClick(tab);
       return;
     }
 

--- a/app/extension/src/model.d.ts
+++ b/app/extension/src/model.d.ts
@@ -26,7 +26,7 @@ interface ShortcutPayload {
 }
 
 interface Message {
-  type: "auto_save_clipper" | "save_clipper" | 'tab_complete' | 'auto_save_tweets' | 'read_tweet' | 'parse_doc' | 'save_clipper_success' | 'shortcuts_preview' | 'shortcuts_execute' | 'shortcuts_process' | 'shortcuts_cancel' | 'shortcuts_processing_start' | 'shortcuts_process_result' | 'shortcuts_process_data' | 'shortcuts_process_error' | 'get_selection' | 'detect_rss_feed' | 'get_huntly_shortcuts' | 'get_ai_toolbar_data' | 'open_tab' | 'open_side_panel' | 'save_detail_init' | 'http_proxy' | 'badge_refresh' | 'fetch_image' | 'get_dragged_image' | 'clear_dragged_image',
+  type: "auto_save_clipper" | "save_clipper" | 'tab_complete' | 'auto_save_tweets' | 'read_tweet' | 'parse_doc' | 'save_clipper_success' | 'shortcuts_preview' | 'shortcuts_execute' | 'shortcuts_process' | 'shortcuts_cancel' | 'shortcuts_processing_start' | 'shortcuts_process_result' | 'shortcuts_process_data' | 'shortcuts_process_error' | 'get_selection' | 'detect_rss_feed' | 'get_huntly_shortcuts' | 'get_ai_toolbar_data' | 'open_tab' | 'open_side_panel' | 'save_detail_init' | 'http_proxy' | 'badge_refresh' | 'fetch_image' | 'get_dragged_image' | 'clear_dragged_image' | 'sidepanel_context_menu_command' | 'consume_pending_sidepanel_context_commands',
   payload?: any,
   url?: string
 }

--- a/app/extension/src/sidepanel/SidepanelApp.tsx
+++ b/app/extension/src/sidepanel/SidepanelApp.tsx
@@ -70,6 +70,7 @@ import {
   createAttachmentPartFromDataUrl,
   createAttachmentPartFromUrl,
   createCurrentPageContextPart,
+  createPageContextPart,
   getDraggedImageSource,
   getTabContext,
   onConfigChange,
@@ -115,8 +116,72 @@ const DROPPABLE_STRING_TYPES = new Set([
   "DownloadURL",
 ]);
 
+type PendingSelectionPageContext = {
+  title?: string;
+  content?: string;
+  url?: string;
+  faviconUrl?: string;
+  description?: string;
+  author?: string;
+  siteName?: string;
+};
+
+type PendingSidepanelContextCommand = {
+  id: string;
+} & (
+  | {
+      kind: "image";
+      source: string;
+    }
+  | {
+      kind: "page-context";
+    }
+  | {
+      kind: "selection";
+      page: PendingSelectionPageContext;
+    }
+);
+
 function isImageDataUrl(value: string): boolean {
   return /^data:image\//i.test(value.trim());
+}
+
+function isPendingSelectionPageContext(
+  value: unknown
+): value is PendingSelectionPageContext {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      (typeof (value as PendingSelectionPageContext).content === "string" ||
+        typeof (value as PendingSelectionPageContext).content === "undefined")
+  );
+}
+
+function isPendingSidepanelContextCommand(
+  value: unknown
+): value is PendingSidepanelContextCommand {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const command = value as PendingSidepanelContextCommand;
+  if (typeof command.id !== "string" || typeof command.kind !== "string") {
+    return false;
+  }
+
+  if (command.kind === "image") {
+    return typeof command.source === "string";
+  }
+
+  if (command.kind === "page-context") {
+    return true;
+  }
+
+  if (command.kind === "selection") {
+    return isPendingSelectionPageContext(command.page);
+  }
+
+  return false;
 }
 
 function isBlobUrl(value: string): boolean {
@@ -527,14 +592,14 @@ export const SidepanelApp: FC = () => {
       }
     ) => void
   >(() => {});
-  const poolRef = useRef<SessionChatPool | null>(null);
-  if (!poolRef.current) {
-    poolRef.current = new SessionChatPool(
-      () => configRef.current,
-      (sessionId, snapshot) =>
-        poolEventHandlerRef.current(sessionId, snapshot)
-    );
-  }
+  const [pool] = useState(
+    () =>
+      new SessionChatPool(
+        () => configRef.current,
+        (sessionId, snapshot) =>
+          poolEventHandlerRef.current(sessionId, snapshot)
+      )
+  );
 
   const cancelTitleGenerationFor = useCallback((sessionId: string) => {
     titleGenerationAbortsRef.current.get(sessionId)?.abort();
@@ -558,8 +623,6 @@ export const SidepanelApp: FC = () => {
   const pruneEmptyDraft = useCallback(
     (sessionId: string | null) => {
       if (!sessionId) return;
-      const pool = poolRef.current;
-      if (!pool) return;
       if (sessionsDataRef.current.has(sessionId)) return;
       if (pool.isRunning(sessionId)) return;
       const chat = pool.get(sessionId);
@@ -568,7 +631,7 @@ export const SidepanelApp: FC = () => {
       previousSessionMessagesRef.current.delete(sessionId);
       cancelTitleGenerationFor(sessionId);
     },
-    [cancelTitleGenerationFor]
+    [cancelTitleGenerationFor, pool]
   );
 
   const syncSessionSnapshot = useCallback(
@@ -782,21 +845,18 @@ export const SidepanelApp: FC = () => {
     (sessionId: string, chatMessages: ChatMessage[]) => {
       // Empty drafts (no messages yet) are kept entirely in-memory and never
       // persisted. They are only created on the user's first send below.
-      const existing = sessionsDataRef.current.get(sessionId);
-      if (chatMessages.length === 0 && !existing) {
-        return;
-      }
       if (chatMessages.length === 0) {
         return;
       }
 
+      const existing = sessionsDataRef.current.get(sessionId);
       let session = existing;
       const isNewSession = !session;
       if (!session) {
-        const created = createEmptySession(
-          currentModelRef.current ? getModelKey(currentModelRef.current) : null
+        session = createEmptySession(
+          currentModelRef.current ? getModelKey(currentModelRef.current) : null,
+          sessionId
         );
-        session = { ...created, id: sessionId };
         sessionsDataRef.current.set(sessionId, session);
       }
 
@@ -807,7 +867,6 @@ export const SidepanelApp: FC = () => {
           ? session.messages[session.messages.length - 1]
           : null;
       const prevLatestId = getStoredLastMessageId(session);
-      const prevLastMessageAt = getStoredLastMessageAt(session);
       const isStreaming = latestMessage?.status === "running";
       const latestChanged =
         isNewSession ||
@@ -820,6 +879,15 @@ export const SidepanelApp: FC = () => {
         return;
       }
 
+      // Only the active session reflects the user-selected model/thinking
+      // switch into its persisted record; background sessions keep whatever
+      // they were configured with at send time so switching the UI model
+      // does not silently rewrite history.
+      const isActiveSession = sessionId === currentSessionIdRef.current;
+      const activeModelKey = currentModelRef.current
+        ? getModelKey(currentModelRef.current)
+        : null;
+
       const updated: SessionData = {
         ...session,
         title: (session.title || "").trim() || DEFAULT_SESSION_TITLE,
@@ -831,22 +899,29 @@ export const SidepanelApp: FC = () => {
           session.titleGenerationStatus === "generated"
             ? session.titleGeneratedAt
             : undefined,
-        currentModelId: currentModelRef.current
-          ? getModelKey(currentModelRef.current)
-          : null,
-        thinkingEnabled: thinkingModeRef.current,
+        currentModelId: isActiveSession
+          ? activeModelKey
+          : session.currentModelId,
+        thinkingEnabled: isActiveSession
+          ? thinkingModeRef.current
+          : session.thinkingEnabled,
         messages: chatMessages,
         updatedAt: now,
         lastMessageAt: now,
         lastMessageId: latestMessage?.id || prevLatestId,
-        lastOpenedAt:
-          currentSessionIdRef.current === session.id
-            ? now
-            : session.lastOpenedAt || session.updatedAt || session.createdAt,
+        lastOpenedAt: isActiveSession
+          ? now
+          : session.lastOpenedAt || session.updatedAt || session.createdAt,
       };
 
-      syncSessionSnapshot(updated, latestMessage?.status !== "running");
-      maybeGenerateSessionTitle(updated, chatMessages);
+      syncSessionSnapshot(updated, !isStreaming);
+
+      // Title generation is off the hot path: only fire once streaming
+      // settles (or when not streaming at all). The inner dedupe still
+      // short-circuits if the title is already generated.
+      if (!isStreaming) {
+        maybeGenerateSessionTitle(updated, chatMessages);
+      }
     },
     [maybeGenerateSessionTitle, syncSessionSnapshot]
   );
@@ -878,9 +953,9 @@ export const SidepanelApp: FC = () => {
   // streaming; only this hook drives composer/MessageList rendering for the
   // currently displayed session.
   const activeChat = useMemo(() => {
-    if (!poolRef.current || !currentSessionId) return null;
-    return poolRef.current.get(currentSessionId);
-  }, [currentSessionId]);
+    if (!currentSessionId) return null;
+    return pool.get(currentSessionId);
+  }, [currentSessionId, pool]);
 
   const chat = useHuntlyChat({
     chat: activeChat,
@@ -904,10 +979,10 @@ export const SidepanelApp: FC = () => {
     if (loading) return;
     if (currentSessionIdRef.current) return;
     const draftId = generateId();
-    poolRef.current?.ensure(draftId);
+    pool.ensure(draftId);
     currentSessionIdRef.current = draftId;
     setCurrentSessionId(draftId);
-  }, [loading]);
+  }, [loading, pool]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1036,9 +1111,9 @@ export const SidepanelApp: FC = () => {
       window.removeEventListener("pagehide", flushPendingSession);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       cancelAllTitleGenerations();
-      poolRef.current?.disposeAll();
+      pool.disposeAll();
     };
-  }, [cancelAllTitleGenerations, persistence]);
+  }, [cancelAllTitleGenerations, persistence, pool]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     messageScrollPinnedRef.current = true;
@@ -1121,9 +1196,10 @@ export const SidepanelApp: FC = () => {
 
   const handleDeleteSession = useCallback(
     async (id: string) => {
+      await persistence.flush();
       persistence.markDeleted(id);
       cancelTitleGenerationFor(id);
-      poolRef.current?.remove(id);
+      pool.remove(id);
       sessionsDataRef.current.delete(id);
       previousSessionMessagesRef.current.delete(id);
 
@@ -1135,7 +1211,7 @@ export const SidepanelApp: FC = () => {
       if (currentSessionIdRef.current === id) {
         // Switch to a fresh draft so the composer is still usable.
         const draftId = generateId();
-        poolRef.current?.ensure(draftId);
+        pool.ensure(draftId);
         currentSessionIdRef.current = draftId;
         setCurrentSessionId(draftId);
         clearInlineUserMessageEdit();
@@ -1146,6 +1222,7 @@ export const SidepanelApp: FC = () => {
       cancelTitleGenerationFor,
       clearInlineUserMessageEdit,
       persistence,
+      pool,
       resetComposerState,
     ]
   );
@@ -1238,9 +1315,6 @@ export const SidepanelApp: FC = () => {
         // Switch sessions WITHOUT cancelling the previously active session.
         // The pool keeps that Chat alive so its stream continues in the
         // background; persistence and title generation stay wired up.
-        const pool = poolRef.current;
-        if (!pool) return;
-
         let openedSession: SessionData | null =
           sessionsDataRef.current.get(id) ?? null;
         let chatMessages: ChatMessage[];
@@ -1314,6 +1388,7 @@ export const SidepanelApp: FC = () => {
       clearInlineUserMessageEdit,
       maybeGenerateSessionTitle,
       persistence,
+      pool,
       pruneEmptyDraft,
       resetComposerState,
     ]
@@ -1322,9 +1397,6 @@ export const SidepanelApp: FC = () => {
   const handleNewChat = useCallback(() => {
     // Don't cancel any running session. Just open a fresh draft chat; the
     // previous session keeps streaming via the pool until it completes.
-    const pool = poolRef.current;
-    if (!pool) return;
-
     const previousId = currentSessionIdRef.current;
     const draftId = generateId();
     pool.ensure(draftId);
@@ -1337,7 +1409,7 @@ export const SidepanelApp: FC = () => {
     setSlashPromptIndex(0);
     resetComposerState();
     inputRef.current?.focus();
-  }, [clearInlineUserMessageEdit, pruneEmptyDraft, resetComposerState]);
+  }, [clearInlineUserMessageEdit, pool, pruneEmptyDraft, resetComposerState]);
 
   const prepareOutgoingText = useCallback(
     (text: string) => {
@@ -1404,6 +1476,163 @@ export const SidepanelApp: FC = () => {
     }
   }, []);
 
+  const appendPendingContextCommands = useCallback(
+    async (commands: PendingSidepanelContextCommand[]) => {
+      if (commands.length === 0) {
+        return [] as string[];
+      }
+
+      setAttachmentProcessingLabel(
+        commands.length > 1
+          ? "Processing chat context..."
+          : "Processing chat context..."
+      );
+
+      const completedIds: string[] = [];
+      try {
+        for (const command of commands) {
+          if (command.kind === "image") {
+            const attached = await addAttachmentFromSource(command.source);
+            if (attached) {
+              completedIds.push(command.id);
+            }
+            continue;
+          }
+
+          if (command.kind === "page-context") {
+            try {
+              const part = await createCurrentPageContextPart();
+              setAttachedPageContext(part);
+              setContextError(null);
+              completedIds.push(command.id);
+            } catch (error) {
+              console.error("[SidepanelApp] Failed to attach page context", error);
+              setContextError("Unable to read this tab");
+            }
+            continue;
+          }
+
+          try {
+            const part = createPageContextPart(command.page, {
+              title: command.page.title || "Selected content",
+              url: command.page.url,
+              faviconUrl: command.page.faviconUrl,
+            });
+            setAttachedPageContext(part);
+            setContextError(null);
+            completedIds.push(command.id);
+          } catch (error) {
+            console.error("[SidepanelApp] Failed to attach selection context", error);
+            setContextError("Unable to read this selection");
+          }
+        }
+
+        if (completedIds.length > 0) {
+          inputRef.current?.focus();
+        }
+
+        return completedIds;
+      } finally {
+        setAttachmentProcessingLabel(null);
+      }
+    },
+    [addAttachmentFromSource]
+  );
+
+  // Keep the latest append callback in a ref so the runtime message listener
+  // below can stay mount-once. Re-subscribing the listener on every render
+  // re-invoked `consume_pending_sidepanel_context_commands`, which
+  // double-consumed pending commands from the background page.
+  const appendPendingContextCommandsRef = useRef(appendPendingContextCommands);
+  useEffect(() => {
+    appendPendingContextCommandsRef.current = appendPendingContextCommands;
+  }, [appendPendingContextCommands]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const handleRuntimeMessage = (
+      message: unknown,
+      _sender: unknown,
+      sendResponse: (response?: unknown) => void
+    ) => {
+      const typedMessage = message as
+        | {
+            type?: string;
+            payload?: { command?: unknown };
+          }
+        | undefined;
+      if (typedMessage?.type !== "sidepanel_context_menu_command") {
+        return undefined;
+      }
+
+      const command = typedMessage.payload?.command;
+      if (!isPendingSidepanelContextCommand(command)) {
+        sendResponse({
+          success: false,
+          error: "Invalid sidepanel context command.",
+        });
+        return undefined;
+      }
+
+      void appendPendingContextCommandsRef.current([command])
+        .then((completedIds) => {
+          const completed = completedIds.includes(command.id);
+          sendResponse({
+            success: completed,
+            commandId: completed ? command.id : null,
+          });
+        })
+        .catch((error) => {
+          console.error("[SidepanelApp] Failed to handle context menu command", error);
+          sendResponse({
+            success: false,
+            error: (error as Error)?.message || "Failed to process command",
+          });
+        });
+
+      return true;
+    };
+
+    const consumePendingContextCommands = async () => {
+      try {
+        const currentWindow = await chrome.windows.getCurrent();
+        if (cancelled || typeof currentWindow.id !== "number") {
+          return;
+        }
+
+        const response = (await chrome.runtime.sendMessage({
+          type: "consume_pending_sidepanel_context_commands",
+          payload: {
+            windowId: currentWindow.id,
+          },
+        })) as unknown as { commands?: unknown } | undefined;
+        const pendingCommands = Array.isArray(response?.commands)
+          ? response.commands.filter(isPendingSidepanelContextCommand)
+          : [];
+
+        if (!cancelled && pendingCommands.length > 0) {
+          await appendPendingContextCommandsRef.current(pendingCommands);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error(
+            "[SidepanelApp] Failed to consume pending sidepanel commands",
+            error
+          );
+        }
+      }
+    };
+
+    chrome.runtime.onMessage.addListener(handleRuntimeMessage);
+    void consumePendingContextCommands();
+
+    return () => {
+      cancelled = true;
+      chrome.runtime.onMessage.removeListener(handleRuntimeMessage);
+    };
+  }, []);
+
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const dragDepthRef = useRef(0);
   const internalDragRef = useRef(false);
@@ -1463,17 +1692,13 @@ export const SidepanelApp: FC = () => {
       dragDepthRef.current = 0;
       setIsDraggingOver(false);
 
+      const dataTransfer = event.dataTransfer;
+
       void (async () => {
-        const filesFromItems = dedupeFiles(
-          Array.from(event.dataTransfer.items || [])
-            .filter((item) => item.kind === "file")
-            .map((item) => item.getAsFile())
-            .filter((file): file is File => Boolean(file))
+        const { files, sources } = await extractDroppedPayload(
+          dataTransfer,
+          tabContext?.url
         );
-        const files =
-          filesFromItems.length > 0
-            ? filesFromItems
-            : dedupeFiles(Array.from(event.dataTransfer.files || []));
 
         if (files.length > 0) {
           setAttachmentProcessingLabel(
@@ -1493,11 +1718,6 @@ export const SidepanelApp: FC = () => {
         }
 
         if (!attached) {
-          const { sources } = await extractDroppedPayload(
-            event.dataTransfer,
-            tabContext?.url
-          );
-
           for (const source of sources) {
             attached = await addAttachmentFromSource(source);
             if (attached) {

--- a/app/extension/src/sidepanel/agentTools.ts
+++ b/app/extension/src/sidepanel/agentTools.ts
@@ -1,30 +1,31 @@
 /**
  * Agent tools for the Huntly AI sidebar.
  *
- * Each tool wraps an existing Huntly extension capability (page content
- * extraction, Huntly API calls, etc.) as an AI SDK tool so the assistant
- * can invoke them autonomously during a conversation.
+ * Local tools wrap browser capabilities. Huntly MCP tools are loaded
+ * automatically when the user configured a Huntly server and is logged in.
  */
 
+import { createMCPClient, type MCPClient, type MCPClientConfig } from "@ai-sdk/mcp";
 import { tool } from "ai";
 import TurndownService from "turndown";
 import { z } from "zod";
-import {
-  archivePage,
-  deletePage,
-  getApiBaseUrl,
-  getPageDetail,
-  readLaterPage,
-  removePageFromLibrary,
-  saveArticle,
-  savePageToLibrary,
-  starPage,
-  unReadLaterPage,
-  unStarPage,
-} from "../services";
-import { postData } from "../utils";
+import { readSyncStorageSettings } from "../storage";
 
 const turndown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+const HUNTLY_MCP_SSE_PATH = "api/mcp/sse";
+const MCP_TOOL_TITLE_PREFIX = "MCP";
+
+type AgentToolSet = Record<string, any>;
+
+export interface AgentToolMetadata {
+  source: "local" | "mcp";
+  sourceLabel?: string;
+}
+
+const agentToolMetadataByName: Record<string, AgentToolMetadata> = {
+  get_page_content: { source: "local" },
+  get_page_selection: { source: "local" },
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -46,31 +47,6 @@ async function sendToActiveTab(message: any): Promise<any> {
   });
 }
 
-function parseJson(value: string | null | undefined): any {
-  if (!value) return null;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-}
-
-function extractSavedPageId(response: unknown): number {
-  if (typeof response === "number") return response;
-  if (!response || typeof response !== "object") return 0;
-
-  const data = (response as { data?: unknown }).data;
-  return typeof data === "number" ? data : 0;
-}
-
-function notifyBadgeRefresh(): void {
-  try {
-    chrome.runtime.sendMessage({ type: "badge_refresh" });
-  } catch {
-    // Badge refresh is best-effort.
-  }
-}
-
 function getPageDomain(url: string): string {
   try {
     return new URL(url).hostname;
@@ -79,26 +55,127 @@ function getPageDomain(url: string): string {
   }
 }
 
-async function getActiveParsedPage(): Promise<any> {
-  const resp = await sendToActiveTab({ type: "parse_doc" });
-  const page = resp?.page;
-  if (!page?.url || !page?.content) {
-    throw new Error("Could not extract page content.");
+function normalizeUrl(url: string | null | undefined): string {
+  const trimmed = url?.trim() || "";
+  if (!trimmed) return "";
+  return trimmed.endsWith("/") ? trimmed : `${trimmed}/`;
+}
+
+function registerAgentToolMetadata(
+  toolName: string,
+  metadata: AgentToolMetadata
+): void {
+  agentToolMetadataByName[toolName] = metadata;
+}
+
+export function getAgentToolMetadata(
+  toolName: string | null | undefined
+): AgentToolMetadata | undefined {
+  if (!toolName) {
+    return undefined;
   }
 
+  return agentToolMetadataByName[toolName];
+}
+
+export function formatAgentToolTitle(
+  metadata: AgentToolMetadata | undefined
+): string | undefined {
+  if (!metadata || metadata.source !== "mcp") {
+    return undefined;
+  }
+
+  const sourceLabel = metadata.sourceLabel?.trim();
+  return sourceLabel
+    ? `${MCP_TOOL_TITLE_PREFIX} · ${sourceLabel}`
+    : MCP_TOOL_TITLE_PREFIX;
+}
+
+export function parseAgentToolTitle(
+  title: string | null | undefined
+): AgentToolMetadata | undefined {
+  const trimmed = title?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (trimmed === MCP_TOOL_TITLE_PREFIX) {
+    return { source: "mcp" };
+  }
+
+  const prefix = `${MCP_TOOL_TITLE_PREFIX} · `;
+  if (!trimmed.startsWith(prefix)) {
+    return undefined;
+  }
+
+  const sourceLabel = trimmed.slice(prefix.length).trim();
   return {
-    ...page,
-    domain: page.domain || getPageDomain(page.url),
+    source: "mcp",
+    sourceLabel: sourceLabel || undefined,
   };
 }
 
-function requirePageId(pageId: number | undefined): number {
-  if (!pageId || pageId <= 0) {
-    throw new Error("pageId is required.");
+const HUNTLY_MCP_FETCH: typeof fetch = (input, init) =>
+  fetch(input, {
+    ...init,
+    credentials: "include",
+  });
+
+function mergeAgentTools(
+  target: AgentToolSet,
+  incoming: AgentToolSet,
+  metadata: AgentToolMetadata,
+  sourceLabel: string
+): void {
+  for (const [toolName, toolDefinition] of Object.entries(incoming)) {
+    if (target[toolName]) {
+      console.warn(
+        `[agentTools] Skipping MCP tool "${toolName}" from ${sourceLabel} because the name is already registered.`
+      );
+      continue;
+    }
+
+    target[toolName] = toolDefinition;
+    registerAgentToolMetadata(toolName, metadata);
   }
-  return pageId;
 }
 
+async function closeMcpClients(clients: MCPClient[]): Promise<void> {
+  await Promise.allSettled(clients.map((client) => client.close()));
+}
+
+async function loadMcpTools(options: {
+  transport: MCPClientConfig["transport"];
+  sourceLabel: string;
+  tools: AgentToolSet;
+  clients: MCPClient[];
+}): Promise<void> {
+  try {
+    const client = await createMCPClient({
+      transport: options.transport,
+      onUncaughtError(error) {
+        console.error(
+          `[agentTools] Uncaught MCP error from ${options.sourceLabel}`,
+          error
+        );
+      },
+    });
+
+    const mcpTools = await client.tools();
+    mergeAgentTools(
+      options.tools,
+      mcpTools,
+      { source: "mcp", sourceLabel: options.sourceLabel },
+      options.sourceLabel
+    );
+    options.clients.push(client);
+  } catch (error) {
+    console.error(
+      `[agentTools] Failed to load MCP tools from ${options.sourceLabel}`,
+      error
+    );
+  }
+}
 // ---------------------------------------------------------------------------
 // Tool definitions
 // ---------------------------------------------------------------------------
@@ -163,172 +240,51 @@ export const getPageSelectionTool = tool({
   },
 });
 
-export const savePageToHuntlyTool = tool({
-  description:
-    "Save the current browser tab to Huntly and add it to the user's library. Use this when the user asks to save, capture, or add the current page to Huntly.",
-  inputSchema: z.object({}),
-  async execute() {
-    try {
-      const page = await getActiveParsedPage();
-      const saveResponse = parseJson(await saveArticle(page));
-      const pageId = extractSavedPageId(saveResponse);
-      if (!pageId) {
-        return {
-          error: "Failed to save page.",
-          response: saveResponse,
-        };
-      }
-
-      const operateResult = await savePageToLibrary(pageId);
-      notifyBadgeRefresh();
-
-      return {
-        pageId,
-        title: page.title,
-        url: page.url,
-        operateResult,
-      };
-    } catch (err: any) {
-      return {
-        error: err?.message || "Failed to save current page to Huntly.",
-      };
-    }
-  },
-});
-
-export const searchHuntlyTool = tool({
-  description:
-    "Search saved Huntly content by keyword. Returns matching pages with title, URL, metadata, and library state.",
-  inputSchema: z.object({
-    query: z.string().min(1).describe("Search keywords."),
-    limit: z
-      .number()
-      .int()
-      .min(1)
-      .max(20)
-      .optional()
-      .describe("Maximum number of results to return."),
-    queryOptions: z
-      .string()
-      .optional()
-      .describe(
-        "Optional Huntly search filters, such as title-only or library filters."
-      ),
-  }),
-  async execute({ query, limit = 5, queryOptions }) {
-    try {
-      const baseUri = await getApiBaseUrl();
-      if (!baseUri) {
-        return { error: "Huntly server URL is not configured." };
-      }
-
-      const normalizedQuery = query.trim();
-      if (!normalizedQuery) {
-        return { error: "query is required." };
-      }
-
-      const response = parseJson(
-        await postData(baseUri, "search", {
-          q: normalizedQuery,
-          size: Math.min(limit, 20),
-          queryOptions,
-        })
-      );
-      const items = Array.isArray(response?.items) ? response.items : [];
-
-      return {
-        query: normalizedQuery,
-        totalHits: response?.totalHits ?? items.length,
-        costSeconds: response?.costSeconds,
-        results: items.slice(0, limit).map((item: any) => ({
-          id: item.id,
-          title: item.title,
-          url: item.url,
-          description: item.description,
-          author: item.author,
-          siteName: item.siteName,
-          domain: item.domain,
-          librarySaveStatus: item.librarySaveStatus,
-          starred: item.starred,
-          readLater: item.readLater,
-          markRead: item.markRead,
-          recordAt: item.recordAt,
-          connectedAt: item.connectedAt,
-        })),
-      };
-    } catch (err: any) {
-      return {
-        error: err?.message || "Failed to search Huntly.",
-      };
-    }
-  },
-});
-
-export const huntlyApiTool = tool({
-  description:
-    "Perform common Huntly page operations by page id, including star, archive, read-later, delete, and detail lookup.",
-  inputSchema: z.object({
-    action: z.enum([
-      "get_page_detail",
-      "star_page",
-      "unstar_page",
-      "archive_page",
-      "save_to_library",
-      "remove_from_library",
-      "read_later",
-      "unread_later",
-      "delete_page",
-    ]),
-    pageId: z.number().int().positive().optional(),
-  }),
-  async execute({ action, pageId }) {
-    try {
-      const id = requirePageId(pageId);
-      switch (action) {
-        case "get_page_detail":
-          return await getPageDetail(id);
-        case "star_page":
-          notifyBadgeRefresh();
-          return await starPage(id);
-        case "unstar_page":
-          notifyBadgeRefresh();
-          return await unStarPage(id);
-        case "archive_page":
-          notifyBadgeRefresh();
-          return await archivePage(id);
-        case "save_to_library":
-          notifyBadgeRefresh();
-          return await savePageToLibrary(id);
-        case "remove_from_library":
-          notifyBadgeRefresh();
-          return await removePageFromLibrary(id);
-        case "read_later":
-          notifyBadgeRefresh();
-          return await readLaterPage(id);
-        case "unread_later":
-          notifyBadgeRefresh();
-          return await unReadLaterPage(id);
-        case "delete_page":
-          await deletePage(id);
-          notifyBadgeRefresh();
-          return { deleted: true, pageId: id };
-      }
-    } catch (err: any) {
-      return {
-        error: err?.message || "Failed to call Huntly API.",
-      };
-    }
-  },
-});
-
 // ---------------------------------------------------------------------------
-// All tools as a record (for AI SDK streamText)
+// Local tools and dynamic MCP tool context
 // ---------------------------------------------------------------------------
 
-export const ALL_AGENT_TOOLS = {
+export const LOCAL_AGENT_TOOLS: AgentToolSet = {
   get_page_content: getPageContentTool,
   get_page_selection: getPageSelectionTool,
-  save_page_to_huntly: savePageToHuntlyTool,
-  search_huntly: searchHuntlyTool,
-  huntly_api: huntlyApiTool,
 };
+
+export async function createAgentToolContext(): Promise<{
+  tools: AgentToolSet;
+  close: () => Promise<void>;
+}> {
+  const tools: AgentToolSet = { ...LOCAL_AGENT_TOOLS };
+  const clients: MCPClient[] = [];
+
+  try {
+    const settings = await readSyncStorageSettings();
+    const huntlyServerUrl = normalizeUrl(settings.serverUrl);
+
+    if (huntlyServerUrl) {
+      await loadMcpTools({
+        transport: {
+          type: "sse",
+          url: `${huntlyServerUrl}${HUNTLY_MCP_SSE_PATH}`,
+          fetch: HUNTLY_MCP_FETCH,
+        },
+        sourceLabel: "Huntly server MCP",
+        tools,
+        clients,
+      });
+    }
+  } catch (error) {
+    console.error("[agentTools] Failed to prepare agent tools", error);
+    await closeMcpClients(clients);
+    return {
+      tools: { ...LOCAL_AGENT_TOOLS },
+      close: async () => {},
+    };
+  }
+
+  return {
+    tools,
+    close: async () => {
+      await closeMcpClients(clients);
+    },
+  };
+}

--- a/app/extension/src/sidepanel/chatPool.ts
+++ b/app/extension/src/sidepanel/chatPool.ts
@@ -16,7 +16,7 @@ import {
   type ChatTransport,
 } from "ai";
 
-import { ALL_AGENT_TOOLS } from "./agentTools";
+import { createAgentToolContext } from "./agentTools";
 import type { HuntlyModelInfo } from "./types";
 import {
   CHAT_MAX_OUTPUT_TOKENS,
@@ -94,35 +94,53 @@ function buildTransport(
         } as any);
       }
 
-      const agent = new ToolLoopAgent({
-        model: config.modelInfo.model,
-        instructions: config.systemPrompt,
-        tools: ALL_AGENT_TOOLS,
-        stopWhen: stepCountIs(5),
-        maxOutputTokens: CHAT_MAX_OUTPUT_TOKENS,
-        providerOptions: config.thinkingEnabled
-          ? buildThinkingProviderOptions(config.modelInfo.provider)
-          : buildBaseProviderOptions(config.modelInfo.provider),
-      });
+      const toolContext = await createAgentToolContext();
 
-      const validated = await validateUIMessages({
-        messages,
-        tools: agent.tools as any,
-      });
-      const modelMessages = await convertToModelMessages(
-        replaceInlineFileParts(validated),
-        {
+      try {
+        const agent = new ToolLoopAgent({
+          model: config.modelInfo.model,
+          instructions: config.systemPrompt,
+          tools: toolContext.tools as any,
+          stopWhen: stepCountIs(5),
+          maxOutputTokens: CHAT_MAX_OUTPUT_TOKENS,
+          providerOptions: config.thinkingEnabled
+            ? buildThinkingProviderOptions(config.modelInfo.provider)
+            : buildBaseProviderOptions(config.modelInfo.provider),
+        });
+
+        const validated = await validateUIMessages({
+          messages,
           tools: agent.tools as any,
-          convertDataPart: convertInlineFileDataPart,
+        });
+        const modelMessages = await convertToModelMessages(
+          replaceInlineFileParts(validated),
+          {
+            tools: agent.tools as any,
+            convertDataPart: convertInlineFileDataPart,
+          }
+        );
+        const result = await agent.stream({
+          prompt: modelMessages,
+          abortSignal,
+        });
+        return result.toUIMessageStream({
+          sendReasoning: config.thinkingEnabled,
+          onFinish: async () => {
+            try {
+              await toolContext.close();
+            } catch (error) {
+              console.error("[SessionChatPool] Failed to close MCP clients", error);
+            }
+          },
+        });
+      } catch (error) {
+        try {
+          await toolContext.close();
+        } catch (closeError) {
+          console.error("[SessionChatPool] Failed to close MCP clients", closeError);
         }
-      );
-      const result = await agent.stream({
-        prompt: modelMessages,
-        abortSignal,
-      });
-      return result.toUIMessageStream({
-        sendReasoning: config.thinkingEnabled,
-      });
+        throw error;
+      }
     },
     async reconnectToStream() {
       return null;

--- a/app/extension/src/sidepanel/components/ToolCallBlock.tsx
+++ b/app/extension/src/sidepanel/components/ToolCallBlock.tsx
@@ -57,6 +57,14 @@ const ToolCallBlockImpl: FC<ToolCallBlockProps> = ({ part }) => {
         onClick={() => setOpen((value) => !value)}
       >
         <Wrench className="size-4 shrink-0" />
+        {part.toolSource === "mcp" && (
+          <span
+            className="shrink-0 rounded bg-[#efe8dc] px-1.5 py-0.5 text-[10px] font-medium text-[#7b6f62]"
+            title={part.toolSourceLabel || "MCP tool"}
+          >
+            MCP
+          </span>
+        )}
         <span className="min-w-0 flex-1 truncate font-medium">
           {part.toolName || "Tool call"}
         </span>

--- a/app/extension/src/sidepanel/sessionStorage.ts
+++ b/app/extension/src/sidepanel/sessionStorage.ts
@@ -661,10 +661,13 @@ export async function deleteSession(sessionId: string): Promise<void> {
   );
 }
 
-export function createEmptySession(currentModelId: string | null): SessionData {
+export function createEmptySession(
+  currentModelId: string | null,
+  id?: string
+): SessionData {
   const now = new Date().toISOString();
   return {
-    id: crypto.randomUUID(),
+    id: id ?? crypto.randomUUID(),
     title: DEFAULT_SESSION_TITLE,
     titleGenerationStatus: "idle",
     currentModelId,

--- a/app/extension/src/sidepanel/systemPrompt.ts
+++ b/app/extension/src/sidepanel/systemPrompt.ts
@@ -1,19 +1,21 @@
 import { getPromptsSettings } from "../storage";
 
-const SIDEPANEL_SYSTEM_PROMPT = `You are Huntly AI, an intelligent assistant embedded in the Huntly browser extension. You have access to tools that let you interact with the user's browser and the Huntly information management system.
+const SIDEPANEL_SYSTEM_PROMPT = `You are Huntly AI, an intelligent assistant embedded in the Huntly browser extension. You have access to local browser tools and optional Huntly MCP tools when the user has connected their Huntly server.
 
-Your capabilities:
+Your built-in capabilities:
 - get_page_content: Extract and read the article content of the current browser tab. Use this when the user asks about the current page, wants a summary, translation, or analysis.
 - get_page_selection: Get the text currently selected by the user on the page.
-- save_page_to_huntly: Save the current page to the Huntly library for later reading.
-- search_huntly: Search the user's saved pages in Huntly by keyword.
-- huntly_api: Manage a saved Huntly page by page id. Supported actions include detail lookup, starring, archiving, saving/removing from library, read-later updates, and deletion.
+
+Additional tool sources:
+- When a Huntly server is configured and the user is logged in, Huntly MCP tools may also be available.
 
 Guidelines:
 - If a user message includes an <attached-page-context> block, use that content for current-page requests and do not call get_page_content for that page unless the user asks to refresh it or inspect a different tab.
 - When the user asks about "this page", "the current page", or "this article", use get_page_content first unless attached page context is already provided.
 - When the user mentions "selected text" or "highlighted text", use get_page_selection.
 - When a user message contains a <huntly-prompts> XML block, treat it as a quick prompt. The first line inside the block is the original slash-prompt invocation. Use attached page context when present; otherwise use get_page_content first. Then apply the remaining prompt instructions to that page content. Treat any "User request" text inside the block as additional constraints.
+- Use MCP tools when they are relevant, especially for Huntly knowledge base or other connected services.
+- Do not invent legacy Huntly API tool names or assume a remote MCP tool exists unless it is actually available in the current tool list.
 - Be concise and helpful.
 - When attachments are included, inspect them directly before answering.`;
 

--- a/app/extension/src/sidepanel/types.ts
+++ b/app/extension/src/sidepanel/types.ts
@@ -48,6 +48,9 @@ export interface ChatPart {
   size?: number;
   toolCallId?: string;
   toolName?: string;
+  toolTitle?: string;
+  toolSource?: "local" | "mcp";
+  toolSourceLabel?: string;
   args?: Record<string, unknown>;
   argsText?: string;
   result?: unknown;

--- a/app/extension/src/sidepanel/useHuntlyChat.ts
+++ b/app/extension/src/sidepanel/useHuntlyChat.ts
@@ -21,6 +21,11 @@ import {
   type UIMessageChunk,
 } from "ai";
 import type { ProviderOptions } from "@ai-sdk/provider-utils";
+import {
+  formatAgentToolTitle,
+  getAgentToolMetadata,
+  parseAgentToolTitle,
+} from "./agentTools";
 import type { ChatMessage, ChatPart } from "./types";
 
 export const CHAT_MAX_OUTPUT_TOKENS = 8192;
@@ -216,6 +221,62 @@ function getToolInput(part: ChatPart): unknown {
   return {};
 }
 
+function findToolCallPart(
+  message: ChatMessage | undefined,
+  toolCallId: string | undefined
+): ChatPart | undefined {
+  if (!message || !toolCallId) {
+    return undefined;
+  }
+
+  return message.parts.find(
+    (part) => part.type === "tool-call" && part.toolCallId === toolCallId
+  );
+}
+
+function resolveToolTitle(part: ChatPart): string | undefined {
+  if (part.toolTitle?.trim()) {
+    return part.toolTitle.trim();
+  }
+
+  return formatAgentToolTitle(
+    part.toolSource === "mcp"
+      ? { source: "mcp", sourceLabel: part.toolSourceLabel }
+      : undefined
+  );
+}
+
+function resolveToolPartMetadata(options: {
+  toolName: string;
+  title?: string;
+  previousPart?: ChatPart;
+}): Pick<ChatPart, "toolTitle" | "toolSource" | "toolSourceLabel"> {
+  const normalizedTitle = options.title?.trim() || options.previousPart?.toolTitle;
+  const titleMetadata = parseAgentToolTitle(normalizedTitle);
+  if (titleMetadata) {
+    return {
+      toolTitle: formatAgentToolTitle(titleMetadata),
+      toolSource: titleMetadata.source,
+      toolSourceLabel: titleMetadata.sourceLabel,
+    };
+  }
+
+  if (options.previousPart?.toolSource) {
+    return {
+      toolTitle: options.previousPart.toolTitle,
+      toolSource: options.previousPart.toolSource,
+      toolSourceLabel: options.previousPart.toolSourceLabel,
+    };
+  }
+
+  const metadata = getAgentToolMetadata(options.toolName);
+  return {
+    toolTitle: formatAgentToolTitle(metadata),
+    toolSource: metadata?.source,
+    toolSourceLabel: metadata?.sourceLabel,
+  };
+}
+
 function dataUrlToBase64(dataUrl: string): string {
   const commaIndex = dataUrl.indexOf(",");
   if (commaIndex === -1) {
@@ -349,6 +410,7 @@ function convertAssistantChatMessageToUIMessage(
         if (!part.toolCallId || !part.toolName) break;
 
         const input = getToolInput(part);
+        const title = resolveToolTitle(part);
         if (part.result === undefined) {
           parts.push({
             type: "dynamic-tool",
@@ -356,6 +418,7 @@ function convertAssistantChatMessageToUIMessage(
             toolCallId: part.toolCallId,
             state: "input-available",
             input,
+            title,
           });
           break;
         }
@@ -368,6 +431,7 @@ function convertAssistantChatMessageToUIMessage(
             state: "output-error",
             input,
             errorText: String(part.result || "Tool execution failed."),
+            title,
           });
           break;
         }
@@ -379,6 +443,7 @@ function convertAssistantChatMessageToUIMessage(
           state: "output-available",
           input,
           output: part.result,
+          title,
         });
         break;
       }
@@ -456,7 +521,8 @@ function convertUserUIMessageToChatParts(message: HuntlyUIMessage): ChatPart[] {
 }
 
 function convertAssistantUIMessageToChatParts(
-  message: HuntlyUIMessage
+  message: HuntlyUIMessage,
+  previousMessage?: ChatMessage
 ): ChatPart[] {
   return message.parts.reduce<ChatPart[]>((result, part) => {
     if (part.type === "step-start") {
@@ -487,6 +553,13 @@ function convertAssistantUIMessageToChatParts(
         part.type === "dynamic-tool"
           ? part.toolName
           : part.type.slice("tool-".length);
+      const title = "title" in part ? part.title : undefined;
+      const previousPart = findToolCallPart(previousMessage, part.toolCallId);
+      const toolMetadata = resolveToolPartMetadata({
+        toolName,
+        title,
+        previousPart,
+      });
 
       let toolResult: unknown;
       let isError = false;
@@ -509,6 +582,9 @@ function convertAssistantUIMessageToChatParts(
         type: "tool-call",
         toolCallId: part.toolCallId,
         toolName,
+        toolTitle: toolMetadata.toolTitle,
+        toolSource: toolMetadata.toolSource,
+        toolSourceLabel: toolMetadata.toolSourceLabel,
         args: asRecord(part.input),
         argsText: safeStringify(part.input),
         result: toolResult,
@@ -614,7 +690,10 @@ export function convertUIMessagesToChatMessages(
       role: message.role,
       parts:
         message.role === "assistant"
-          ? convertAssistantUIMessageToChatParts(message)
+          ? convertAssistantUIMessageToChatParts(
+              message,
+              previousMessagesById.get(message.id)
+            )
           : convertUserUIMessageToChatParts(message),
       status: messageStatus,
     });

--- a/app/extension/src/sidepanel/utils/messageParts.ts
+++ b/app/extension/src/sidepanel/utils/messageParts.ts
@@ -83,52 +83,7 @@ function joinMeta(...values: Array<string | undefined>): string | undefined {
 
 type ToolLinkCardExtractor = (result: unknown) => LinkCardGroup[];
 
-function extractSearchHuntlyLinkCards(result: unknown): LinkCardGroup[] {
-  const parsed = parseMaybeJson(result);
-  if (!isRecord(parsed)) return [];
-
-  const rawResults = parsed.results;
-  if (!Array.isArray(rawResults)) return [];
-
-  const items: LinkCardItem[] = [];
-  const seen = new Set<string>();
-
-  for (const item of rawResults) {
-    if (!isRecord(item)) continue;
-
-    const href = getTrimmedString(item.url);
-    const title = getTrimmedString(item.title) || href;
-    if (!href || !title || seen.has(href)) {
-      continue;
-    }
-
-    seen.add(href);
-    items.push({
-      href,
-      title,
-      description: getTrimmedString(item.description),
-      meta: joinMeta(
-        getTrimmedString(item.siteName),
-        getTrimmedString(item.domain),
-        getTrimmedString(item.author)
-      ),
-    });
-  }
-
-  return items.length > 0
-    ? [
-        {
-          id: "search-results",
-          title: "Search results",
-          items,
-        },
-      ]
-    : [];
-}
-
-const TOOL_LINK_CARD_EXTRACTORS: Record<string, ToolLinkCardExtractor> = {
-  search_huntly: extractSearchHuntlyLinkCards,
-};
+const TOOL_LINK_CARD_EXTRACTORS: Record<string, ToolLinkCardExtractor> = {};
 
 export function extractLinkCardGroups(part: ChatPart): LinkCardGroup[] {
   if (

--- a/app/extension/src/sidepanel/utils/tabContext.ts
+++ b/app/extension/src/sidepanel/utils/tabContext.ts
@@ -78,6 +78,33 @@ function buildPageContextMarkdown(page: ParsedPageContext): string {
   return parts.join("\n\n");
 }
 
+export function createPageContextPart(
+  page: ParsedPageContext,
+  fallback?: { title?: string; url?: string; faviconUrl?: string }
+): ChatPart {
+  const tabTitle = fallback?.title || page.title || "Current tab";
+  const articleTitle = page.title;
+  const pageContext: ParsedPageContext = {
+    ...page,
+    title: articleTitle || tabTitle,
+    url: page.url || fallback?.url,
+    faviconUrl: page.faviconUrl || fallback?.faviconUrl,
+  };
+
+  return {
+    id: generateId(),
+    type: "page-context",
+    title: tabTitle,
+    articleTitle,
+    url: pageContext.url,
+    faviconUrl: pageContext.faviconUrl,
+    content: buildPageContextMarkdown(pageContext),
+    description: pageContext.description,
+    author: pageContext.author,
+    siteName: pageContext.siteName,
+  };
+}
+
 export async function createCurrentPageContextPart(): Promise<ChatPart> {
   const [tab] = await chrome.tabs.query({
     active: true,
@@ -94,27 +121,11 @@ export async function createCurrentPageContextPart(): Promise<ChatPart> {
     throw new Error("Could not extract page content.");
   }
 
-  const tabTitle = tab.title || page.title || "Current tab";
-  const articleTitle = page.title;
-  const pageContext: ParsedPageContext = {
-    ...page,
-    title: articleTitle || tabTitle,
-    url: page.url || tab.url,
-    faviconUrl: page.faviconUrl || tab.favIconUrl,
-  };
-
-  return {
-    id: generateId(),
-    type: "page-context",
-    title: tabTitle,
-    articleTitle,
-    url: pageContext.url,
-    faviconUrl: pageContext.faviconUrl,
-    content: buildPageContextMarkdown(pageContext),
-    description: pageContext.description,
-    author: pageContext.author,
-    siteName: pageContext.siteName,
-  };
+  return createPageContextPart(page, {
+    title: tab.title || page.title || "Current tab",
+    url: tab.url,
+    faviconUrl: tab.favIconUrl,
+  });
 }
 
 export function pageContextToTabContext(

--- a/app/extension/yarn.lock
+++ b/app/extension/yarn.lock
@@ -69,6 +69,15 @@
     "@ai-sdk/provider" "3.0.8"
     "@ai-sdk/provider-utils" "4.0.19"
 
+"@ai-sdk/mcp@^1.0.36":
+  version "1.0.36"
+  resolved "https://registry.npmmirror.com/@ai-sdk/mcp/-/mcp-1.0.36.tgz#561d8c3798ac82d3357fb195dfd8a9547c08382d"
+  integrity sha512-THQKwlknp7OU2ViLPfIU7W01XvDRM2eqH+4UULQgP64AopnwI9mGqqJeGIx2l/pxUu9yIDQtW9YtYM8kHm2CQg==
+  dependencies:
+    "@ai-sdk/provider" "3.0.8"
+    "@ai-sdk/provider-utils" "4.0.23"
+    pkce-challenge "^5.0.0"
+
 "@ai-sdk/openai@3.0.41", "@ai-sdk/openai@^3.0.41":
   version "3.0.41"
   resolved "https://registry.npmmirror.com/@ai-sdk/openai/-/openai-3.0.41.tgz#22f559888cd4f9bb312c5c576441c3412f442e7b"
@@ -5329,6 +5338,11 @@ pirates@^4.0.1, pirates@^4.0.4:
   version "4.0.5"
   resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+
+pkce-challenge@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.npmmirror.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz#3b4446865b17b1745e9ace2016a31f48ddf6230d"
+  integrity sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==
 
 pkg-dir@^4.2.0:
   version "4.2.0"

--- a/app/server/huntly-server/src/main/java/com/huntly/server/mcp/McpServerController.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/mcp/McpServerController.java
@@ -7,6 +7,8 @@ import com.huntly.server.mcp.tool.McpTool;
 import com.huntly.server.service.GlobalSettingService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,14 +16,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * MCP Server Controller implementing SSE transport
- * Based on MCP (Model Context Protocol) specification
+ * MCP Server Controller implementing SSE transport.
  */
 @Slf4j
 @RestController
@@ -49,8 +51,14 @@ public class McpServerController {
      * This endpoint is accessible without MCP token (uses session auth)
      */
     @GetMapping(value = "/tools", produces = MediaType.APPLICATION_JSON_VALUE)
-    public java.util.List<Map<String, Object>> getTools() {
-        return toolRegistry.getToolDefinitions();
+    public ResponseEntity<java.util.List<Map<String, Object>>> getTools(
+            Principal principal,
+            @RequestHeader(value = "Authorization", required = false) String authorization) {
+        if (!isAuthorized(principal, authorization)) {
+            return ResponseEntity.status(HttpServletResponse.SC_UNAUTHORIZED).build();
+        }
+
+        return ResponseEntity.ok(toolRegistry.getToolDefinitions());
     }
 
     /**
@@ -58,7 +66,14 @@ public class McpServerController {
      * This endpoint is accessible without MCP token (uses session auth)
      */
     @PostMapping(value = "/tools/test", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Map<String, Object>> testTool(@RequestBody Map<String, Object> request) {
+    public ResponseEntity<Map<String, Object>> testTool(
+            Principal principal,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestBody Map<String, Object> request) {
+        if (!isAuthorized(principal, authorization)) {
+            return ResponseEntity.status(HttpServletResponse.SC_UNAUTHORIZED).build();
+        }
+
         String toolName = (String) request.get("name");
         @SuppressWarnings("unchecked")
         Map<String, Object> arguments = (Map<String, Object>) request.get("arguments");
@@ -90,16 +105,17 @@ public class McpServerController {
      */
     @GetMapping(value = "/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter connect(
+            Principal principal,
             @RequestHeader(value = "Authorization", required = false) String authorization,
             HttpServletResponse response) {
-        if (!validateToken(authorization)) {
-            log.warn("MCP SSE connection rejected: invalid or missing token");
+        if (!isAuthorized(principal, authorization)) {
+            log.warn("MCP SSE connection rejected: invalid or missing authorization");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             SseEmitter emitter = new SseEmitter(0L);
             try {
                 emitter.send(SseEmitter.event()
                         .name("error")
-                        .data("{\"error\": \"Unauthorized: Invalid or missing MCP token\"}"));
+                        .data("{\"error\": \"Unauthorized: Invalid MCP token or missing login\"}"));
                 emitter.complete();
             } catch (IOException e) {
                 log.error("Failed to send error message", e);
@@ -137,11 +153,12 @@ public class McpServerController {
      */
     @PostMapping(value = "/message", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> handleMessage(
+            Principal principal,
             @RequestHeader(value = "Authorization", required = false) String authorization,
             @RequestParam(required = false) String sessionId,
             @RequestBody Map<String, Object> request) {
 
-        if (!validateToken(authorization)) {
+        if (!isAuthorized(principal, authorization)) {
             return ResponseEntity.status(401).build();
         }
 
@@ -257,13 +274,22 @@ public class McpServerController {
                 .data(jsonData));
     }
 
-    private boolean validateToken(String authorization) {
+    private boolean isAuthorized(Principal principal, String authorization) {
+        if (principal != null && StringUtils.isNotBlank(principal.getName())) {
+            return true;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()
+                && !"anonymousUser".equals(authentication.getName())) {
+            return true;
+        }
+
         GlobalSetting setting = globalSettingService.getGlobalSetting();
         String configuredToken = setting.getMcpToken();
 
-        // If no token configured, deny access for security (MCP is disabled)
+        // If no MCP token configured, fall back to login-based access only.
         if (StringUtils.isBlank(configuredToken)) {
-            log.debug("MCP access denied: no token configured");
             return false;
         }
 

--- a/app/server/huntly-server/src/test/java/com/huntly/server/mcp/McpServerControllerTest.java
+++ b/app/server/huntly-server/src/test/java/com/huntly/server/mcp/McpServerControllerTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -56,5 +57,30 @@ class McpServerControllerTest {
                         .content("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
                 .andExpect(status().isAccepted())
                 .andExpect(content().string(""));
+    }
+
+    @Test
+    void handleMessageReturnsAcceptedWhenAuthenticatedByLoginCookieContext() throws Exception {
+        mockMvc.perform(post("/api/mcp/message")
+                        .param("sessionId", SESSION_ID)
+                        .principal(() -> "huntly-user")
+                        .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"))
+                .andExpect(status().isAccepted())
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    void getToolsRejectsUnauthenticatedRequests() throws Exception {
+        mockMvc.perform(get("/api/mcp/tools"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getToolsAllowsAuthenticatedLoginContext() throws Exception {
+        mockMvc.perform(get("/api/mcp/tools")
+                        .principal(() -> "huntly-user"))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## Summary

- **MCP tool integration**: Replace hardcoded Huntly API tools (save, search, huntly_api) with dynamic MCP tool loading via `@ai-sdk/mcp`; tools are fetched from the Huntly server's SSE endpoint at chat start and closed after streaming finishes
- **Context menu enhancements**: Add "Send to Chat" image context menu item that queues image attachments; add selection context support that captures selected page content when right-clicking on a selection
- **Pending command queue**: Background script buffers context commands when the side panel isn't open yet; side panel consumes queued commands on mount
- **MCP tool badge**: `toolSource`/`toolSourceLabel` added to `ChatPart`; MCP-sourced tools display a badge in `ToolCallBlock`
- **Server auth**: `McpServerController.isAuthorized` now accepts Spring Security session login in addition to MCP token, allowing browser-based access without a separate token

## Test plan

- [ ] Verify MCP tools load from Huntly server SSE on chat start and are closed after streaming
- [ ] Right-click an image → "Send to Chat" attaches the image to the side panel composer
- [ ] Right-click selected text → side panel opens with selection context attached
- [ ] Test that pending commands queue correctly when panel is closed and are consumed on open
- [ ] Confirm MCP tool calls show the "MCP" badge in chat messages
- [ ] Run server tests: `./mvnw test -pl huntly-server` — `McpServerControllerTest` should pass including new login-auth cases
- [ ] Run extension tests: `cd app/extension && yarn test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)