### PR TITLE
fix(extension): use compatible Node version in workflows

### DIFF
--- a/.github/workflows/extension-build.yml
+++ b/.github/workflows/extension-build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "20.10.0"
+          node-version: "20.19.0"
           cache: "yarn"
           cache-dependency-path: "app/client/yarn.lock"
       

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "20.10.0"
+          node-version: "20.19.0"
           cache: "yarn"
           cache-dependency-path: "app/extension/yarn.lock"
 


### PR DESCRIPTION
## Summary

- Update extension build and release workflows from Node.js 20.10.0 to 20.19.0.
- Satisfy @vitejs/plugin-react 6.x engine requirement (`^20.19.0 || >=22.12.0`).

## Verification

- Inspected `git diff HEAD` before committing.
- Confirmed only the two extension workflow files were included.
- Pushed commit `0bb815a31a9f25353641a8b10b65622966026e88` to `origin/dev`.