### PR TITLE
fix(extension): remove redundant setOptions call before opening side panel

### DIFF
--- a/app/extension/src/background.ts
+++ b/app/extension/src/background.ts
@@ -1022,18 +1022,6 @@ function openSidePanelForContextMenuClick(tab?: chrome.tabs.Tab): boolean {
     return false;
   }
 
-  if (typeof tab.id === "number" && typeof sidePanelApi.setOptions === "function") {
-    void sidePanelApi
-      .setOptions({
-        tabId: tab.id,
-        path: "sidepanel.html",
-        enabled: true,
-      })
-      .catch((error: unknown) => {
-        log("Failed to configure side panel:", error);
-      });
-  }
-
   void sidePanelApi.open({ windowId: tab.windowId }).catch((error: unknown) => {
     log("Failed to open side panel:", error);
   });


### PR DESCRIPTION
## Summary
- Removes the `sidePanelApi.setOptions()` call that was made before opening the side panel in `openSidePanelForContextMenuClick`
- The `setOptions` call (configuring tabId, path, and enabled) was redundant since `sidePanelApi.open()` handles opening directly

## Test plan
- [ ] Verify side panel opens correctly via context menu click
- [ ] Confirm no regressions in side panel behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)