### PR TITLE
feat(mcp,extension,client): date-range search, agent abort support, i18n fixes

### DIFF
--- a/app/client/src/components/PageList.tsx
+++ b/app/client/src/components/PageList.tsx
@@ -7,7 +7,7 @@ import {useInView} from "react-intersection-observer";
 import React, {ReactElement, useEffect, useState, useRef, useCallback, useMemo} from "react";
 import {Button} from "@mui/material";
 import Loading from "./Loading";
-import {NavLabel} from "./Navigation/shared/NavLabels";
+import {getTranslatedLabel, NavLabel} from "./Navigation/shared/NavLabels";
 import SubHeader, {ButtonOptions} from "./SubHeader";
 import {PageOperateEvent, PageOperation} from "./PageOperationButtons";
 import {PageQueryKey} from "../domain/pageQueryKey";
@@ -80,7 +80,7 @@ const PageList = (props: PageListProps) => {
   const queryClient = useQueryClient();
   const [params, setParams] = useSearchParams();
   const { markReadOnScroll } = useGlobalSettings();
-  const { t } = useTranslation(['page']);
+  const { t, i18n } = useTranslation(['page', 'navigation']);
 
   // ============ Basic State ============
   const selectedPageId = safeInt(params.get("p"));
@@ -436,11 +436,11 @@ const PageList = (props: PageListProps) => {
 
   useEffect(() => {
     if (selectedPageId === 0) {
-      setDocTitle(navLabel.labelText);
+      setDocTitle(getTranslatedLabel(navLabel));
     } else {
       setLastVisitPageId(selectedPageId);
     }
-  }, [selectedPageId, navLabel]);
+  }, [selectedPageId, navLabel, i18n.language]);
 
   useEffect(() => {
     if (inView && !isLoading && !isFetchingNextPage) {

--- a/app/client/src/pages/Highlights.tsx
+++ b/app/client/src/pages/Highlights.tsx
@@ -314,13 +314,13 @@ const Highlights: React.FC = () => {
 
   React.useEffect(() => {
     setDocTitle(t('page:myHighlightsTitle'));
-  }, []);
+  }, [t]);
 
   React.useEffect(() => {
     if (selectedPageId === 0) {
       setDocTitle(t('page:myHighlightsTitle'));
     }
-  }, [selectedPageId]);
+  }, [selectedPageId, t]);
 
   const allHighlights = data?.pages.flatMap(page => page?.content || []) || [];
   const totalCount = data?.pages[0]?.totalElements || 0;

--- a/app/client/src/pages/Home.tsx
+++ b/app/client/src/pages/Home.tsx
@@ -249,6 +249,7 @@ const Home = () => {
     <MainContainer>
       <SubHeader
         navLabel={navLabels.home}
+        documentTitle={t('navigation:home')}
         buttonOptions={{ markRead: false, viewSwitch: false }}
       />
       <Box sx={{ p: { xs: 2, md: 4 }, maxWidth: '100vw', overflowX: 'hidden' }}>

--- a/app/client/src/pages/Page.tsx
+++ b/app/client/src/pages/Page.tsx
@@ -49,6 +49,7 @@ const Page = () => {
     <MainContainer>
       <SubHeader
         navLabel={articleNavLabel}
+        documentTitle={pageDisplayTitle || t('page:article')}
         buttonOptions={{ markRead: false, viewSwitch: false }}
         hideSearchOnMobile={true}
       />

--- a/app/client/src/pages/Search.tsx
+++ b/app/client/src/pages/Search.tsx
@@ -23,7 +23,7 @@ import SearchIcon from "@mui/icons-material/Search";
 export default function Search() {
   const {ref: inViewRef, inView} = useInView();
   const {enqueueSnackbar} = useSnackbar();
-  const { t } = useTranslation(['search']);
+  const { t } = useTranslation(['search', 'navigation']);
   const [searchParams, setSearchParams] = useSearchParams();
   const q = searchParams.get('q');
   const options = searchParams.get("op");
@@ -32,6 +32,7 @@ export default function Search() {
   const [draftQuery, setDraftQuery] = useState('');
   const [draftOptions, setDraftOptions] = useState<string[]>([]);
   const [focusSignal, setFocusSignal] = useState(0);
+  const searchDocumentTitle = t('navigation:search');
 
   // Quick search suggestions with their keywords
   const quickSearchSuggestions = [
@@ -50,11 +51,11 @@ export default function Search() {
 
   useEffect(() => {
     if (hasSearchQuery) {
-      setDocTitle(q + " - Search");
+      setDocTitle(`${q} - ${searchDocumentTitle}`);
     } else {
-      setDocTitle("Search");
+      setDocTitle(searchDocumentTitle);
     }
-  }, [q, hasSearchQuery]);
+  }, [q, hasSearchQuery, searchDocumentTitle]);
 
   const query: SearchQuery = {q, size: 10, queryOptions: options};
   const queryKey = [PageQueryKey.Search, query];

--- a/app/client/src/pages/settings/SettingsAccount.tsx
+++ b/app/client/src/pages/settings/SettingsAccount.tsx
@@ -3,13 +3,16 @@ import AccountSetting from "../../components/SettingModal/AccountSetting";
 import SubHeader from "../../components/SubHeader";
 import AccountBoxIcon from '@mui/icons-material/AccountBox';
 import "../../styles/settings.css";
+import { useTranslation } from "react-i18next";
 
 const SettingsAccount = () => {
+  const { t } = useTranslation('settings');
+
   return (
     <MainContainer>
       <SubHeader
-        documentTitle="Account Settings"
-        navLabel={{ labelText: 'Account', labelIcon: AccountBoxIcon }}
+        documentTitle={t('account')}
+        navLabel={{ labelText: t('account'), labelIcon: AccountBoxIcon }}
         buttonOptions={{ markRead: false }}
       />
       <div className="settings-page-content p-6 max-w-4xl">

--- a/app/client/src/pages/settings/SettingsFeeds.tsx
+++ b/app/client/src/pages/settings/SettingsFeeds.tsx
@@ -3,13 +3,16 @@ import { FeedsSetting } from "../../components/SettingModal/FeedsSetting";
 import SubHeader from "../../components/SubHeader";
 import RssFeedIcon from '@mui/icons-material/RssFeed';
 import "../../styles/settings.css";
+import { useTranslation } from "react-i18next";
 
 const SettingsFeeds = () => {
+  const { t } = useTranslation('settings');
+
   return (
     <MainContainer>
       <SubHeader
-        documentTitle="Feeds Settings"
-        navLabel={{ labelText: 'Feeds', labelIcon: RssFeedIcon }}
+        documentTitle={t('feeds')}
+        navLabel={{ labelText: t('feeds'), labelIcon: RssFeedIcon }}
         buttonOptions={{ markRead: false }}
       />
       <div className="settings-page-content p-6 max-w-4xl">

--- a/app/client/src/pages/settings/SettingsGeneral.tsx
+++ b/app/client/src/pages/settings/SettingsGeneral.tsx
@@ -3,13 +3,16 @@ import GeneralSetting from "../../components/SettingModal/GeneralSetting";
 import SubHeader from "../../components/SubHeader";
 import SettingsIcon from '@mui/icons-material/Settings';
 import "../../styles/settings.css";
+import { useTranslation } from "react-i18next";
 
 const SettingsGeneral = () => {
+  const { t } = useTranslation('settings');
+
   return (
     <MainContainer>
       <SubHeader
-        documentTitle="General Settings"
-        navLabel={{ labelText: 'General', labelIcon: SettingsIcon }}
+        documentTitle={t('general')}
+        navLabel={{ labelText: t('general'), labelIcon: SettingsIcon }}
         buttonOptions={{ markRead: false }}
       />
       <div className="settings-page-content p-6 max-w-4xl">

--- a/app/client/src/pages/settings/SettingsGithub.tsx
+++ b/app/client/src/pages/settings/SettingsGithub.tsx
@@ -3,13 +3,16 @@ import { GithubSetting } from "../../components/SettingModal/GithubSetting";
 import SubHeader from "../../components/SubHeader";
 import GitHubIcon from '@mui/icons-material/GitHub';
 import "../../styles/settings.css";
+import { useTranslation } from "react-i18next";
 
 const SettingsGithub = () => {
+  const { t } = useTranslation('settings');
+
   return (
     <MainContainer>
       <SubHeader
-        documentTitle="GitHub Settings"
-        navLabel={{ labelText: 'GitHub', labelIcon: GitHubIcon }}
+        documentTitle={t('github')}
+        navLabel={{ labelText: t('github'), labelIcon: GitHubIcon }}
         buttonOptions={{ markRead: false }}
       />
       <div className="settings-page-content p-6 max-w-4xl">

--- a/app/client/src/pages/settings/SettingsHuntlyAI.tsx
+++ b/app/client/src/pages/settings/SettingsHuntlyAI.tsx
@@ -3,13 +3,16 @@ import HuntlyAISetting from "../../components/SettingModal/HuntlyAISetting";
 import SubHeader from "../../components/SubHeader";
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import "../../styles/settings.css";
+import { useTranslation } from "react-i18next";
 
 const SettingsHuntlyAI = () => {
+  const { t } = useTranslation('settings');
+
   return (
     <MainContainer>
       <SubHeader
-        documentTitle="Huntly AI Settings"
-        navLabel={{ labelText: 'Huntly AI', labelIcon: AutoAwesomeIcon }}
+        documentTitle={t('huntlyAI')}
+        navLabel={{ labelText: t('huntlyAI'), labelIcon: AutoAwesomeIcon }}
         buttonOptions={{ markRead: false }}
       />
       <div className="settings-page-content p-6 max-w-4xl">

--- a/app/client/src/pages/settings/SettingsLibrary.tsx
+++ b/app/client/src/pages/settings/SettingsLibrary.tsx
@@ -3,13 +3,16 @@ import LibrarySetting from "../../components/SettingModal/LibrarySetting";
 import SubHeader from "../../components/SubHeader";
 import LibraryBooksIcon from '@mui/icons-material/LibraryBooks';
 import "../../styles/settings.css";
+import { useTranslation } from "react-i18next";
 
 const SettingsLibrary = () => {
+  const { t } = useTranslation('settings');
+
   return (
     <MainContainer>
       <SubHeader
-        documentTitle="Library Settings"
-        navLabel={{ labelText: 'Library', labelIcon: LibraryBooksIcon }}
+        documentTitle={t('library')}
+        navLabel={{ labelText: t('library'), labelIcon: LibraryBooksIcon }}
         buttonOptions={{ markRead: false }}
       />
       <div className="settings-page-content p-6 max-w-4xl">

--- a/app/client/src/pages/settings/SettingsX.tsx
+++ b/app/client/src/pages/settings/SettingsX.tsx
@@ -3,6 +3,7 @@ import XSetting from "../../components/SettingModal/XSetting";
 import SubHeader from "../../components/SubHeader";
 import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
 import "../../styles/settings.css";
+import { useTranslation } from "react-i18next";
 
 // X (Twitter) Icon Component - same as in PrimaryNavigation
 function XIcon(props: SvgIconProps) {
@@ -14,11 +15,13 @@ function XIcon(props: SvgIconProps) {
 }
 
 const SettingsX = () => {
+  const { t } = useTranslation('navigation');
+
   return (
     <MainContainer>
       <SubHeader
-        documentTitle="X Settings"
-        navLabel={{ labelText: 'X', labelIcon: XIcon }}
+        documentTitle={t('x')}
+        navLabel={{ labelText: t('x'), labelIcon: XIcon }}
         buttonOptions={{ markRead: false }}
       />
       <div className="settings-page-content p-6 max-w-4xl">

--- a/app/extension/src/__tests__/UserMessage.test.tsx
+++ b/app/extension/src/__tests__/UserMessage.test.tsx
@@ -1,0 +1,103 @@
+/** @jest-environment jsdom */
+
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+
+import { UserMessage } from "../sidepanel/components/UserMessage";
+import type { ChatMessage } from "../sidepanel/types";
+
+jest.mock("../sidepanel/components/HighlightedPromptText", () => ({
+  HighlightedPromptText: ({ text }: { text: string }) => {
+    const React = require("react");
+    return React.createElement("span", null, text);
+  },
+}));
+
+jest.mock("../i18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createUserMessage(): ChatMessage {
+  return {
+    id: "user-1",
+    role: "user",
+    parts: [{ type: "text", text: "Hello Huntly" }],
+    status: "complete",
+  };
+}
+
+function renderUserMessage(
+  props: Partial<React.ComponentProps<typeof UserMessage>> = {}
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <UserMessage isRunning={false} message={createUserMessage()} {...props} />
+    );
+  });
+
+  return {
+    container,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("UserMessage", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows retry between copy and edit for user messages", () => {
+    const onEdit = jest.fn();
+    const onRetry = jest.fn();
+    const { container, cleanup } = renderUserMessage({ onEdit, onRetry });
+    const buttons = Array.from(container.querySelectorAll("button"));
+
+    expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "common.copy",
+      "sidepanel.retryResponse",
+      "sidepanel.editMessage",
+    ]);
+
+    act(() => {
+      buttons[1].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onRetry).toHaveBeenCalledWith("user-1");
+
+    cleanup();
+  });
+
+  it("uses the edit enablement logic for retry", () => {
+    const { container, cleanup } = renderUserMessage({
+      isRunning: true,
+      onEdit: jest.fn(),
+      onRetry: jest.fn(),
+    });
+    const retryButton = container.querySelector(
+      'button[aria-label="sidepanel.retryResponse"]'
+    ) as HTMLButtonElement | null;
+    const editButton = container.querySelector(
+      'button[aria-label="sidepanel.editMessage"]'
+    ) as HTMLButtonElement | null;
+
+    expect(retryButton?.disabled).toBe(true);
+    expect(editButton?.disabled).toBe(true);
+
+    cleanup();
+  });
+});

--- a/app/extension/src/__tests__/agentToolsAbort.test.ts
+++ b/app/extension/src/__tests__/agentToolsAbort.test.ts
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+
+const mockCreateMCPClient = jest.fn();
+const mockReadSyncStorageSettings = jest.fn();
+
+let createAgentToolContext: typeof import("../sidepanel/agentTools")["createAgentToolContext"];
+
+function loadAgentToolsModule() {
+  jest.resetModules();
+  jest.doMock("@ai-sdk/mcp", () => ({
+    createMCPClient: mockCreateMCPClient,
+  }));
+  jest.doMock("ai", () => ({
+    tool: (definition: unknown) => definition,
+  }));
+  jest.doMock("../storage", () => ({
+    readSyncStorageSettings: mockReadSyncStorageSettings,
+  }));
+
+  const agentTools =
+    require("../sidepanel/agentTools") as typeof import("../sidepanel/agentTools");
+  createAgentToolContext = agentTools.createAgentToolContext;
+}
+
+describe("createAgentToolContext", () => {
+  beforeEach(() => {
+    mockCreateMCPClient.mockReset();
+    mockReadSyncStorageSettings.mockReset();
+    loadAgentToolsModule();
+  });
+
+  it("passes the abort signal to MCP tool listing and closes clients on abort", async () => {
+    const controller = new AbortController();
+    const close = jest.fn(async () => undefined);
+    const listTools = jest.fn(async () => ({ tools: [] }));
+    const toolsFromDefinitions = jest.fn(() => ({}));
+
+    mockReadSyncStorageSettings.mockResolvedValue({
+      serverUrl: "https://huntly.example",
+    });
+    mockCreateMCPClient.mockResolvedValue({
+      close,
+      listTools,
+      toolsFromDefinitions,
+    });
+
+    const context = await createAgentToolContext({
+      abortSignal: controller.signal,
+    });
+
+    expect(listTools).toHaveBeenCalledWith({
+      options: { signal: controller.signal },
+    });
+
+    controller.abort();
+    await Promise.resolve();
+
+    expect(close).toHaveBeenCalled();
+
+    await context.close();
+  });
+
+  it("rejects instead of falling back to local tools when aborted while loading MCP tools", async () => {
+    const controller = new AbortController();
+    let rejectListTools: ((error: Error) => void) | undefined;
+    const close = jest.fn(async () => {
+      rejectListTools?.(new Error("Connection closed"));
+    });
+
+    mockReadSyncStorageSettings.mockResolvedValue({
+      serverUrl: "https://huntly.example",
+    });
+    mockCreateMCPClient.mockResolvedValue({
+      close,
+      listTools: jest.fn(
+        () =>
+          new Promise((_, reject) => {
+            rejectListTools = reject;
+          })
+      ),
+      toolsFromDefinitions: jest.fn(() => ({})),
+    });
+
+    const pendingContext = createAgentToolContext({
+      abortSignal: controller.signal,
+    });
+
+    for (let attempt = 0; attempt < 10 && !rejectListTools; attempt += 1) {
+      await Promise.resolve();
+    }
+    expect(rejectListTools).toBeDefined();
+
+    controller.abort(new Error("stop requested"));
+
+    await expect(pendingContext).rejects.toThrow(/aborted|stop requested/i);
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/app/extension/src/__tests__/sidepanelScrollToBottom.test.ts
+++ b/app/extension/src/__tests__/sidepanelScrollToBottom.test.ts
@@ -1,18 +1,191 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
 import {
   isScrollPinnedToBottom,
   shouldShowScrollToBottomButton,
 } from "../sidepanel/utils/scrollToBottom";
+import { useScrollPinToBottom } from "../sidepanel/hooks/useScrollPinToBottom";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type ScrollHookSnapshot = {
+  handleScroll: () => void;
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+};
+
+const TEST_THRESHOLD_PX = 160;
+
+let latestHook: ScrollHookSnapshot | null = null;
+
+function ScrollHarness({ messages }: { messages: string[] }) {
+  const hook = useScrollPinToBottom({
+    messages,
+    thresholdPx: TEST_THRESHOLD_PX,
+  });
+  latestHook = hook;
+
+  return React.createElement(
+    "div",
+    { ref: hook.scrollContainerRef, "data-testid": "scroll-container" },
+    React.createElement(
+      "div",
+      null,
+      React.createElement("div", { ref: hook.messagesEndRef })
+    )
+  );
+}
+
+function renderScrollHarness(messages: string[] = ["hello"]) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(React.createElement(ScrollHarness, { messages }));
+  });
+
+  const scrollContainer = container.querySelector(
+    '[data-testid="scroll-container"]'
+  );
+  if (!(scrollContainer instanceof HTMLDivElement)) {
+    throw new Error("Scroll container not found");
+  }
+
+  return { container, root, scrollContainer };
+}
+
+function rerenderScrollHarness(root: Root, messages: string[]) {
+  act(() => {
+    root.render(React.createElement(ScrollHarness, { messages }));
+  });
+}
+
+function setScrollMetrics(
+  element: HTMLDivElement,
+  metrics: { clientHeight: number; scrollHeight: number; scrollTop: number }
+) {
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    value: metrics.scrollTop,
+    writable: true,
+  });
+}
+
+function unmount(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+beforeEach(() => {
+  latestHook = null;
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
 
 describe("sidepanel scroll-to-bottom helpers", () => {
   it("treats positions within the threshold as pinned to the bottom", () => {
     expect(isScrollPinnedToBottom(12, 96)).toBe(true);
     expect(isScrollPinnedToBottom(95, 96)).toBe(true);
-    expect(isScrollPinnedToBottom(96, 96)).toBe(false);
+    expect(isScrollPinnedToBottom(96, 96)).toBe(true);
+    expect(isScrollPinnedToBottom(97, 96)).toBe(false);
   });
 
   it("shows the down-arrow button only when there are messages and the view is not pinned", () => {
     expect(shouldShowScrollToBottomButton(0, false)).toBe(false);
     expect(shouldShowScrollToBottomButton(3, true)).toBe(false);
     expect(shouldShowScrollToBottomButton(3, false)).toBe(true);
+  });
+});
+
+describe("useScrollPinToBottom", () => {
+  it("keeps output pinned to the bottom while already at the bottom", () => {
+    const { container, root, scrollContainer } = renderScrollHarness();
+    setScrollMetrics(scrollContainer, {
+      clientHeight: 300,
+      scrollHeight: 720,
+      scrollTop: 420,
+    });
+
+    Object.defineProperty(scrollContainer, "scrollHeight", {
+      configurable: true,
+      value: 900,
+    });
+    rerenderScrollHarness(root, ["hello", "streaming"]);
+
+    expect(scrollContainer.scrollTop).toBe(600);
+    unmount(root, container);
+  });
+
+  it("stops auto-scrolling after the user scrolls away", () => {
+    const { container, root, scrollContainer } = renderScrollHarness();
+    setScrollMetrics(scrollContainer, {
+      clientHeight: 300,
+      scrollHeight: 720,
+      scrollTop: 120,
+    });
+
+    act(() => {
+      latestHook?.handleScroll();
+    });
+
+    Object.defineProperty(scrollContainer, "scrollHeight", {
+      configurable: true,
+      value: 900,
+    });
+    rerenderScrollHarness(root, ["hello", "streaming"]);
+
+    expect(scrollContainer.scrollTop).toBe(120);
+    unmount(root, container);
+  });
+
+  it("resumes auto-scrolling when the user returns near the bottom", () => {
+    const { container, root, scrollContainer } = renderScrollHarness();
+    setScrollMetrics(scrollContainer, {
+      clientHeight: 300,
+      scrollHeight: 720,
+      scrollTop: 120,
+    });
+
+    act(() => {
+      latestHook?.handleScroll();
+    });
+
+    setScrollMetrics(scrollContainer, {
+      clientHeight: 300,
+      scrollHeight: 900,
+      scrollTop: 460,
+    });
+
+    act(() => {
+      latestHook?.handleScroll();
+    });
+
+    Object.defineProperty(scrollContainer, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+    });
+    rerenderScrollHarness(root, ["hello", "streaming"]);
+
+    expect(scrollContainer.scrollTop).toBe(700);
+    unmount(root, container);
   });
 });

--- a/app/extension/src/sidepanel/SidepanelApp.tsx
+++ b/app/extension/src/sidepanel/SidepanelApp.tsx
@@ -140,7 +140,7 @@ function getChromeApi(): ChromeApi | undefined {
   return (globalThis as typeof globalThis & { chrome?: ChromeApi }).chrome;
 }
 
-const SCROLL_PIN_THRESHOLD_PX = 96;
+const SCROLL_PIN_THRESHOLD_PX = 160;
 
 export const SidepanelApp: FC = () => {
   const { t } = useI18n();

--- a/app/extension/src/sidepanel/agentTools.ts
+++ b/app/extension/src/sidepanel/agentTools.ts
@@ -5,17 +5,28 @@
  * automatically when the user configured a Huntly server and is logged in.
  */
 
-import { createMCPClient, type MCPClient, type MCPClientConfig } from "@ai-sdk/mcp";
+import {
+  createMCPClient,
+  type MCPClient,
+  type MCPClientConfig,
+} from "@ai-sdk/mcp";
 import { tool } from "ai";
 import TurndownService from "turndown";
 import { z } from "zod";
 import { readSyncStorageSettings } from "../storage";
 
-const turndown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+const turndown = new TurndownService({
+  headingStyle: "atx",
+  codeBlockStyle: "fenced",
+});
 const HUNTLY_MCP_SSE_PATH = "api/mcp/sse";
 const MCP_TOOL_TITLE_PREFIX = "MCP";
 
 type AgentToolSet = Record<string, any>;
+
+interface AgentToolContextOptions {
+  abortSignal?: AbortSignal;
+}
 
 export interface AgentToolMetadata {
   source: "local" | "mcp";
@@ -25,6 +36,7 @@ export interface AgentToolMetadata {
 const agentToolMetadataByName: Record<string, AgentToolMetadata> = {
   get_page_content: { source: "local" },
   get_page_selection: { source: "local" },
+  get_current_time: { source: "local" },
 };
 
 // ---------------------------------------------------------------------------
@@ -59,6 +71,17 @@ function normalizeUrl(url: string | null | undefined): string {
   const trimmed = url?.trim() || "";
   if (!trimmed) return "";
   return trimmed.endsWith("/") ? trimmed : `${trimmed}/`;
+}
+
+function formatUtcOffset(date: Date): string {
+  const totalMinutes = -date.getTimezoneOffset();
+  const sign = totalMinutes >= 0 ? "+" : "-";
+  const absoluteMinutes = Math.abs(totalMinutes);
+  const hours = Math.floor(absoluteMinutes / 60)
+    .toString()
+    .padStart(2, "0");
+  const minutes = (absoluteMinutes % 60).toString().padStart(2, "0");
+  return `UTC${sign}${hours}:${minutes}`;
 }
 
 function registerAgentToolMetadata(
@@ -121,6 +144,65 @@ const HUNTLY_MCP_FETCH: typeof fetch = (input, init) =>
     credentials: "include",
   });
 
+function createAbortError(signal?: AbortSignal): Error {
+  const reason = signal?.reason;
+  if (reason instanceof Error) {
+    return reason;
+  }
+
+  if (typeof DOMException !== "undefined") {
+    return new DOMException("The operation was aborted.", "AbortError");
+  }
+
+  const error = new Error("The operation was aborted.");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError(signal);
+  }
+}
+
+function isAbortError(error: unknown, signal?: AbortSignal): boolean {
+  return (
+    Boolean(signal?.aborted) ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+function combineAbortSignals(
+  first?: AbortSignal | null,
+  second?: AbortSignal
+): AbortSignal | undefined {
+  if (!first) return second;
+  if (!second) return first;
+  if (first.aborted) return first;
+  if (second.aborted) return second;
+
+  const controller = new AbortController();
+  const abortFrom = (source: AbortSignal) => {
+    if (!controller.signal.aborted) {
+      controller.abort(source.reason);
+    }
+  };
+
+  first.addEventListener("abort", () => abortFrom(first), { once: true });
+  second.addEventListener("abort", () => abortFrom(second), { once: true });
+  return controller.signal;
+}
+
+function createHuntlyMcpFetch(abortSignal?: AbortSignal): typeof fetch {
+  return (input, init) => {
+    throwIfAborted(abortSignal);
+    return HUNTLY_MCP_FETCH(input, {
+      ...init,
+      signal: combineAbortSignals(init?.signal, abortSignal),
+    });
+  };
+}
+
 function mergeAgentTools(
   target: AgentToolSet,
   incoming: AgentToolSet,
@@ -149,9 +231,12 @@ async function loadMcpTools(options: {
   sourceLabel: string;
   tools: AgentToolSet;
   clients: MCPClient[];
+  abortSignal?: AbortSignal;
 }): Promise<void> {
+  let client: MCPClient | null = null;
   try {
-    const client = await createMCPClient({
+    throwIfAborted(options.abortSignal);
+    client = await createMCPClient({
       transport: options.transport,
       onUncaughtError(error) {
         console.error(
@@ -161,15 +246,32 @@ async function loadMcpTools(options: {
       },
     });
 
-    const mcpTools = await client.tools();
+    options.clients.push(client);
+    const definitions = await client.listTools({
+      options: { signal: options.abortSignal },
+    });
+    throwIfAborted(options.abortSignal);
+
+    const mcpTools = client.toolsFromDefinitions(definitions);
     mergeAgentTools(
       options.tools,
       mcpTools,
       { source: "mcp", sourceLabel: options.sourceLabel },
       options.sourceLabel
     );
-    options.clients.push(client);
   } catch (error) {
+    if (client) {
+      const clientIndex = options.clients.indexOf(client);
+      if (clientIndex !== -1) {
+        options.clients.splice(clientIndex, 1);
+      }
+      await client.close().catch(() => undefined);
+    }
+
+    if (isAbortError(error, options.abortSignal)) {
+      throw createAbortError(options.abortSignal);
+    }
+
     console.error(
       `[agentTools] Failed to load MCP tools from ${options.sourceLabel}`,
       error
@@ -240,6 +342,33 @@ export const getPageSelectionTool = tool({
   },
 });
 
+export const getCurrentTimeTool = tool({
+  description:
+    "Get the current local date and time from the user's device, including timezone and UTC offset. Use this when the user asks for the current time, today's date, or needs time-aware reasoning anchored to now.",
+  inputSchema: z.object({}),
+  async execute() {
+    try {
+      const now = new Date();
+      const timeZone =
+        Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+      const localDateTime = new Intl.DateTimeFormat(undefined, {
+        dateStyle: "full",
+        timeStyle: "long",
+      }).format(now);
+
+      return [
+        `**Current local time:** ${localDateTime}`,
+        `**ISO 8601:** ${now.toISOString()}`,
+        `**Time zone:** ${timeZone}`,
+        `**UTC offset:** ${formatUtcOffset(now)}`,
+        `**Unix timestamp (ms):** ${now.getTime()}`,
+      ].join("\n");
+    } catch (err: any) {
+      return `Error: ${err.message || "Failed to get current time"}`;
+    }
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Local tools and dynamic MCP tool context
 // ---------------------------------------------------------------------------
@@ -247,17 +376,31 @@ export const getPageSelectionTool = tool({
 export const LOCAL_AGENT_TOOLS: AgentToolSet = {
   get_page_content: getPageContentTool,
   get_page_selection: getPageSelectionTool,
+  get_current_time: getCurrentTimeTool,
 };
 
-export async function createAgentToolContext(): Promise<{
+export async function createAgentToolContext(
+  options: AgentToolContextOptions = {}
+): Promise<{
   tools: AgentToolSet;
   close: () => Promise<void>;
 }> {
   const tools: AgentToolSet = { ...LOCAL_AGENT_TOOLS };
   const clients: MCPClient[] = [];
+  const { abortSignal } = options;
+  const closeOnAbort = () => {
+    void closeMcpClients(clients);
+  };
+  const removeAbortListener = () => {
+    abortSignal?.removeEventListener("abort", closeOnAbort);
+  };
 
   try {
+    throwIfAborted(abortSignal);
+    abortSignal?.addEventListener("abort", closeOnAbort, { once: true });
+
     const settings = await readSyncStorageSettings();
+    throwIfAborted(abortSignal);
     const huntlyServerUrl = normalizeUrl(settings.serverUrl);
 
     if (huntlyServerUrl) {
@@ -265,16 +408,23 @@ export async function createAgentToolContext(): Promise<{
         transport: {
           type: "sse",
           url: `${huntlyServerUrl}${HUNTLY_MCP_SSE_PATH}`,
-          fetch: HUNTLY_MCP_FETCH,
+          fetch: createHuntlyMcpFetch(abortSignal),
         },
         sourceLabel: "Huntly server MCP",
         tools,
         clients,
+        abortSignal,
       });
     }
   } catch (error) {
-    console.error("[agentTools] Failed to prepare agent tools", error);
+    removeAbortListener();
     await closeMcpClients(clients);
+
+    if (isAbortError(error, abortSignal)) {
+      throw createAbortError(abortSignal);
+    }
+
+    console.error("[agentTools] Failed to prepare agent tools", error);
     return {
       tools: { ...LOCAL_AGENT_TOOLS },
       close: async () => {},
@@ -284,6 +434,7 @@ export async function createAgentToolContext(): Promise<{
   return {
     tools,
     close: async () => {
+      removeAbortListener();
       await closeMcpClients(clients);
     },
   };

--- a/app/extension/src/sidepanel/chatPool.ts
+++ b/app/extension/src/sidepanel/chatPool.ts
@@ -89,6 +89,7 @@ type HuntlyChatInstance = Chat<HuntlyUIMessage> & {
 };
 
 const CHAT_POLL_INTERVAL_MS = 100;
+const AGENT_TOOL_LOOP_MAX_STEPS = 50;
 
 function isChatRunning(status: ChatStatus): boolean {
   return status === "submitted" || status === "streaming";
@@ -274,14 +275,14 @@ export class SessionChatPool {
     messages: HuntlyUIMessage[],
     abortSignal: AbortSignal
   ): Promise<ReadableStream<any>> {
-    const toolContext = await createAgentToolContext();
+    const toolContext = await createAgentToolContext({ abortSignal });
 
     try {
       const agent = new ToolLoopAgent({
         model: config.modelInfo.model,
         instructions: config.systemPrompt,
         tools: toolContext.tools as any,
-        stopWhen: stepCountIs(5),
+        stopWhen: stepCountIs(AGENT_TOOL_LOOP_MAX_STEPS),
         maxOutputTokens: CHAT_MAX_OUTPUT_TOKENS,
         providerOptions: config.thinkingEnabled
           ? buildThinkingProviderOptions(config.modelInfo.provider)

--- a/app/extension/src/sidepanel/components/MessageList.tsx
+++ b/app/extension/src/sidepanel/components/MessageList.tsx
@@ -52,6 +52,7 @@ export const MessageList: FC<MessageListProps> = ({
                 onCancelEdit={onCancelUserMessageEdit}
                 onEdit={onEditUserMessage}
                 onEditingTextChange={onEditUserMessageTextChange}
+                onRetry={onRegenerate}
                 onSaveEdit={onSaveUserMessageEdit}
               />
             );

--- a/app/extension/src/sidepanel/components/UserMessage.tsx
+++ b/app/extension/src/sidepanel/components/UserMessage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState, type FC } from "react";
-import { Check, Copy, Paperclip, PencilLine, X } from "lucide-react";
+import { Check, Copy, Paperclip, PencilLine, RotateCcw, X } from "lucide-react";
 import { MessageFooter } from "./MessageFooter";
 import type { ChatMessage } from "../types";
 import { useAutosizeTextArea } from "../utils/dom";
@@ -18,6 +18,7 @@ interface UserMessageProps {
   onCancelEdit?: () => void;
   onEdit?: (messageId: string) => void;
   onEditingTextChange?: (value: string) => void;
+  onRetry?: (messageId: string) => void;
   onSaveEdit?: (messageId: string) => void;
 }
 
@@ -29,6 +30,7 @@ const UserMessageImpl: FC<UserMessageProps> = ({
   onCancelEdit,
   onEdit,
   onEditingTextChange,
+  onRetry,
   onSaveEdit,
 }) => {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -36,9 +38,10 @@ const UserMessageImpl: FC<UserMessageProps> = ({
   const [copyFeedbackVisible, setCopyFeedbackVisible] = useState(false);
   const copyResetTimeoutRef = useRef<number | null>(null);
   const editInputRef = useRef<HTMLTextAreaElement>(null);
-  const display = useMemo(() => getDisplayMessage(message.parts), [
-    message.parts,
-  ]);
+  const display = useMemo(
+    () => getDisplayMessage(message.parts),
+    [message.parts]
+  );
   const text = display.text;
   const pageContexts = message.parts.filter(
     (part) => part.type === "page-context"
@@ -52,7 +55,9 @@ const UserMessageImpl: FC<UserMessageProps> = ({
   const bubbleClassName = isEditing
     ? "w-full rounded-xl border border-[#d8cfbf] bg-[#fffdf9] px-4 py-3 text-[15px] leading-6 text-[#332a22] shadow-[0_8px_24px_rgba(64,48,31,0.06)] focus-within:border-[#c28b63] focus-within:ring-2 focus-within:ring-[#c28b63]/20"
     : "max-w-full rounded-2xl bg-[#e9dcc7] px-4 py-3 text-[15px] leading-6 text-[#332a22] shadow-sm";
-  const canSaveEdit = Boolean(editingText.trim() || attachments.length > 0 || pageContexts.length > 0);
+  const canSaveEdit = Boolean(
+    editingText.trim() || attachments.length > 0 || pageContexts.length > 0
+  );
 
   useAutosizeTextArea(editInputRef, isEditing ? editingText : text);
 
@@ -224,7 +229,9 @@ const UserMessageImpl: FC<UserMessageProps> = ({
                   active={copyFeedbackVisible}
                   className={footerButtonClassName}
                   disabled={!text}
-                  label={copyFeedbackVisible ? t("common.copied") : t("common.copy")}
+                  label={
+                    copyFeedbackVisible ? t("common.copied") : t("common.copy")
+                  }
                   onClick={handleCopy}
                 >
                   {copyFeedbackVisible ? (
@@ -233,6 +240,16 @@ const UserMessageImpl: FC<UserMessageProps> = ({
                     <Copy className="size-4" />
                   )}
                 </IconButton>
+                {onRetry && (
+                  <IconButton
+                    className={footerButtonClassName}
+                    disabled={isRunning}
+                    label={t("sidepanel.retryResponse")}
+                    onClick={() => onRetry(message.id)}
+                  >
+                    <RotateCcw className="size-4" />
+                  </IconButton>
+                )}
                 {onEdit && (
                   <IconButton
                     className={footerButtonClassName}
@@ -263,7 +280,9 @@ const UserMessageImpl: FC<UserMessageProps> = ({
             </button>
             <img
               src={previewUrl}
-              alt={t("sidepanel.previewLabel", { label: t("sidepanel.attachment") })}
+              alt={t("sidepanel.previewLabel", {
+                label: t("sidepanel.attachment"),
+              })}
               className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-lg"
               onClick={(event) => event.stopPropagation()}
             />

--- a/app/extension/src/sidepanel/hooks/useScrollPinToBottom.ts
+++ b/app/extension/src/sidepanel/hooks/useScrollPinToBottom.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 
 import {
   isScrollPinnedToBottom,
@@ -39,7 +45,24 @@ export function useScrollPinToBottom<T>(
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     pinnedRef.current = true;
     setShowScrollToBottom(false);
-    messagesEndRef.current?.scrollIntoView({ block: "end", behavior });
+
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) {
+      messagesEndRef.current?.scrollIntoView({ block: "end", behavior });
+      return;
+    }
+
+    const top = Math.max(
+      scrollContainer.scrollHeight - scrollContainer.clientHeight,
+      0
+    );
+
+    if (behavior === "auto" || typeof scrollContainer.scrollTo !== "function") {
+      scrollContainer.scrollTop = top;
+      return;
+    }
+
+    scrollContainer.scrollTo({ top, behavior });
   }, []);
 
   const handleScroll = useCallback(() => {
@@ -58,7 +81,7 @@ export function useScrollPinToBottom<T>(
     );
   }, [messages.length, thresholdPx]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (messages.length === 0) {
       pinnedRef.current = true;
       setShowScrollToBottom(false);
@@ -72,8 +95,7 @@ export function useScrollPinToBottom<T>(
       return;
     }
 
-    const frame = window.requestAnimationFrame(() => scrollToBottom("auto"));
-    return () => window.cancelAnimationFrame(frame);
+    scrollToBottom("auto");
   }, [messages, scrollToBottom]);
 
   return {

--- a/app/extension/src/sidepanel/utils/scrollToBottom.ts
+++ b/app/extension/src/sidepanel/utils/scrollToBottom.ts
@@ -2,7 +2,7 @@ export function isScrollPinnedToBottom(
   distanceToBottom: number,
   thresholdPx: number
 ): boolean {
-  return distanceToBottom < thresholdPx;
+  return distanceToBottom <= thresholdPx;
 }
 
 export function shouldShowScrollToBottomButton(

--- a/app/server/huntly-interfaces/src/main/java/com/huntly/interfaces/external/query/SearchQuery.java
+++ b/app/server/huntly-interfaces/src/main/java/com/huntly/interfaces/external/query/SearchQuery.java
@@ -15,6 +15,20 @@ public class SearchQuery {
     private String q;
     
     private String queryOptions;
+
+    private String contentType;
+
+    private String libraryFilter;
+
+    private Boolean alreadyRead;
+
+    private Boolean searchTitleOnly;
+
+    private String startDate;
+
+    private String endDate;
+
+    private String dateField;
     
     private Integer page;
     

--- a/app/server/huntly-server/src/main/java/com/huntly/server/mcp/McpServerController.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/mcp/McpServerController.java
@@ -78,9 +78,7 @@ public class McpServerController {
             return ResponseEntity.status(HttpServletResponse.SC_UNAUTHORIZED).build();
         }
 
-        String toolName = (String) request.get("name");
-        @SuppressWarnings("unchecked")
-        Map<String, Object> arguments = (Map<String, Object>) request.get("arguments");
+        String toolName = request.get("name") instanceof String ? (String) request.get("name") : null;
 
         Map<String, Object> response = new HashMap<>();
 
@@ -92,7 +90,7 @@ public class McpServerController {
 
         try {
             McpTool tool = toolRegistry.getTool(toolName);
-            Object result = tool.execute(arguments != null ? arguments : new HashMap<>());
+            Object result = executeTool(tool, getToolArguments(request.get("arguments")));
             response.put("success", true);
             response.put("result", result);
             return ResponseEntity.ok(response);
@@ -240,17 +238,16 @@ public class McpServerController {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
     private Map<String, Object> handleToolCall(Map<String, Object> params) {
-        String toolName = (String) params.get("name");
-        Map<String, Object> arguments = (Map<String, Object>) params.get("arguments");
+        String toolName = params != null && params.get("name") instanceof String ? (String) params.get("name") : null;
+        Map<String, Object> arguments = getToolArguments(params != null ? params.get("arguments") : null);
 
         if (!toolRegistry.hasTool(toolName)) {
             throw new IllegalArgumentException("Unknown tool: " + toolName);
         }
 
         McpTool tool = toolRegistry.getTool(toolName);
-        Object result = tool.execute(arguments != null ? arguments : new HashMap<>());
+        Object result = executeTool(tool, arguments);
 
         // Detect error-shaped payloads (Map with "error" key)
         boolean isError = result instanceof Map && ((Map<?, ?>) result).containsKey("error");
@@ -269,6 +266,34 @@ public class McpServerController {
         response.put("isError", isError);
 
         return response;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getToolArguments(Object arguments) {
+        if (arguments == null) {
+            return new HashMap<>();
+        }
+        if (!(arguments instanceof Map)) {
+            throw new IllegalArgumentException("Tool arguments must be a JSON object");
+        }
+        return (Map<String, Object>) arguments;
+    }
+
+    private Object executeTool(McpTool tool, Map<String, Object> arguments) {
+        try {
+            return tool.execute(arguments != null ? arguments : new HashMap<>());
+        } catch (Throwable e) {
+            if (e instanceof VirtualMachineError || e instanceof ThreadDeath) {
+                throw e;
+            }
+            throw new IllegalStateException("Tool execution failed: " + getThrowableMessage(e), e);
+        }
+    }
+
+    private String getThrowableMessage(Throwable throwable) {
+        return StringUtils.isNotBlank(throwable.getMessage())
+                ? throwable.getMessage()
+                : throwable.getClass().getSimpleName();
     }
 
     private void sendEvent(SseEmitter emitter, String eventName, Object data) throws IOException {

--- a/app/server/huntly-server/src/main/java/com/huntly/server/mcp/McpUtils.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/mcp/McpUtils.java
@@ -111,7 +111,9 @@ public class McpUtils {
                 .id(pageItem.getId())
                 .url(pageItem.getUrl())
                 .huntlyUrl(buildHuntlyUrl(pageItem.getId()))
-                .contentType(contentType);
+                .contentType(contentType)
+                .collectionId(pageItem.getCollectionId())
+                .collectedAt(pageItem.getCollectedAt() != null ? pageItem.getCollectedAt().toString() : null);
 
         // For tweets, use content field instead of title; for articles, use title
         if (isTweet) {
@@ -179,7 +181,9 @@ public class McpUtils {
                 .markRead(pageItem.getMarkRead())
                 .recordAt(pageItem.getRecordAt() != null ? pageItem.getRecordAt().toString() : null)
                 .publishedAt(pageItem.getConnectedAt() != null ? pageItem.getConnectedAt().toString() : null)
-                .voteScore(pageItem.getVoteScore());
+                .voteScore(pageItem.getVoteScore())
+                .collectionId(pageItem.getCollectionId())
+                .collectedAt(pageItem.getCollectedAt() != null ? pageItem.getCollectedAt().toString() : null);
 
         // Parse tweet-specific fields
         parseTweetProperties(pageItem.getPageJsonProperties(), builder);
@@ -203,7 +207,9 @@ public class McpUtils {
                 .readLater(pageItem.getReadLater())
                 .markRead(pageItem.getMarkRead())
                 .recordAt(pageItem.getRecordAt() != null ? pageItem.getRecordAt().toString() : null)
-                .publishedAt(pageItem.getConnectedAt() != null ? pageItem.getConnectedAt().toString() : null);
+                .publishedAt(pageItem.getConnectedAt() != null ? pageItem.getConnectedAt().toString() : null)
+                .collectionId(pageItem.getCollectionId())
+                .collectedAt(pageItem.getCollectedAt() != null ? pageItem.getCollectedAt().toString() : null);
 
         if (!titleOnly) {
             builder.author(pageItem.getAuthor())
@@ -246,7 +252,9 @@ public class McpUtils {
                 .recordAt(page.getConnectedAt() != null ? page.getConnectedAt().toString() : null)
                 .publishedAt(page.getConnectedAt() != null ? page.getConnectedAt().toString() : null)
                 .voteScore(page.getVoteScore())
-                .connectorId(page.getConnectorId());
+                .connectorId(page.getConnectorId())
+                .collectionId(page.getCollectionId())
+                .collectedAt(page.getCollectedAt() != null ? page.getCollectedAt().toString() : null);
 
         if (isTweet) {
             // Parse tweet text using the same logic as frontend Tweet.tsx

--- a/app/server/huntly-server/src/main/java/com/huntly/server/mcp/dto/McpPageItem.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/mcp/dto/McpPageItem.java
@@ -42,6 +42,8 @@ public class McpPageItem {
     private Long voteScore;
     private Integer connectorId;
     private String connectorName;
+    private Long collectionId;
+    private String collectedAt;
 
     // Tweet-specific fields
     private Long favoriteCount;

--- a/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/GetXSaveRulesTool.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/GetXSaveRulesTool.java
@@ -1,0 +1,199 @@
+package com.huntly.server.mcp.tool;
+
+import com.huntly.interfaces.external.model.LibrarySaveType;
+import com.huntly.server.domain.entity.TwitterUserSetting;
+import com.huntly.server.domain.vo.CollectionGroupVO;
+import com.huntly.server.domain.vo.CollectionTreeVO;
+import com.huntly.server.domain.vo.CollectionVO;
+import com.huntly.server.service.CollectionService;
+import com.huntly.server.service.TwitterUserSettingService;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * MCP Tool: get_x_save_rules - Get configured X/Twitter save rules
+ */
+@Component
+public class GetXSaveRulesTool implements McpTool {
+
+    private final TwitterUserSettingService twitterUserSettingService;
+    private final CollectionService collectionService;
+
+    public GetXSaveRulesTool(TwitterUserSettingService twitterUserSettingService,
+            CollectionService collectionService) {
+        this.twitterUserSettingService = twitterUserSettingService;
+        this.collectionService = collectionService;
+    }
+
+    @Override
+    public String getName() {
+        return "get_x_save_rules";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Get Huntly X/Twitter save rules. Use this before analyzing or searching X content to identify which X accounts belong to the user (is_myself=true), and to understand where tweets authored by each account, bookmarks, and likes are saved: My List, Starred, Read Later, Archive, or a specific collection. The returned display_name is the tweet author name indexed by Huntly and can be used with search_content advanced search, for example author:\"Display Name\"; use screen_name only for X account identity, not for author: search.";
+    }
+
+    @Override
+    public Map<String, Object> getInputSchema() {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("properties", new LinkedHashMap<>());
+        return schema;
+    }
+
+    @Override
+    public Object execute(Map<String, Object> arguments) {
+        List<TwitterUserSetting> settings = twitterUserSettingService.getTwitterUserSettings();
+        Map<Long, Map<String, Object>> collectionLookup = buildCollectionLookup(collectionService.getTreeWithoutCounts());
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("count", settings.size());
+        response.put("my_accounts", settings.stream()
+                .filter(setting -> Boolean.TRUE.equals(setting.getMyself()))
+                .map(this::toAccountResponse)
+                .collect(Collectors.toList()));
+        response.put("rules", settings.stream()
+                .map(setting -> toRuleResponse(setting, collectionLookup))
+                .collect(Collectors.toList()));
+        return response;
+    }
+
+    private Map<String, Object> toRuleResponse(TwitterUserSetting setting,
+            Map<Long, Map<String, Object>> collectionLookup) {
+        Map<String, Object> response = toAccountResponse(setting);
+        response.put("is_myself", Boolean.TRUE.equals(setting.getMyself()));
+        response.put("tweets", toDestinationResponse(
+                setting.getTweetToLibraryType(),
+                setting.getTweetToCollectionId(),
+                collectionLookup));
+        response.put("bookmarks", toDestinationResponse(
+                setting.getBookmarkToLibraryType(),
+                setting.getBookmarkToCollectionId(),
+                collectionLookup));
+        response.put("likes", toDestinationResponse(
+                setting.getLikeToLibraryType(),
+                setting.getLikeToCollectionId(),
+                collectionLookup));
+        return response;
+    }
+
+    private Map<String, Object> toAccountResponse(TwitterUserSetting setting) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("id", setting.getId());
+        response.put("display_name", setting.getName());
+        response.put("screen_name", setting.getScreenName());
+        response.put("author_search_query", buildAuthorSearchQuery(setting.getName()));
+        return response;
+    }
+
+    private Map<String, Object> toDestinationResponse(Integer saveTypeCode, Long collectionId,
+            Map<Long, Map<String, Object>> collectionLookup) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("enabled", isDestinationEnabled(saveTypeCode, collectionId));
+        response.put("save_type_code", saveTypeCode);
+        response.put("save_type", toConfiguredSaveType(saveTypeCode));
+        response.put("effective_save_type", toEffectiveSaveType(saveTypeCode, collectionId));
+        response.put("collection", toCollectionResponse(collectionId, collectionLookup));
+        return response;
+    }
+
+    private boolean isDestinationEnabled(Integer saveTypeCode, Long collectionId) {
+        return (saveTypeCode != null && saveTypeCode > 0) || collectionId != null;
+    }
+
+    private String toConfiguredSaveType(Integer saveTypeCode) {
+        LibrarySaveType saveType = LibrarySaveType.fromCode(saveTypeCode);
+        if (saveType == null) {
+            return null;
+        }
+        return toSaveTypeName(saveType);
+    }
+
+    private String toEffectiveSaveType(Integer saveTypeCode, Long collectionId) {
+        if (collectionId != null && (saveTypeCode == null || saveTypeCode == 0)) {
+            return "my_list";
+        }
+        LibrarySaveType saveType = LibrarySaveType.fromCode(saveTypeCode);
+        if (saveType == null || saveType == LibrarySaveType.NONE) {
+            return null;
+        }
+        return toSaveTypeName(saveType);
+    }
+
+    private String toSaveTypeName(LibrarySaveType saveType) {
+        switch (saveType) {
+            case NONE:
+                return "none";
+            case MY_LIST:
+                return "my_list";
+            case STARRED:
+                return "starred";
+            case READ_LATER:
+                return "read_later";
+            case ARCHIVE:
+                return "archive";
+            default:
+                return null;
+        }
+    }
+
+    private Map<String, Object> toCollectionResponse(Long collectionId,
+            Map<Long, Map<String, Object>> collectionLookup) {
+        if (collectionId == null) {
+            return null;
+        }
+        Map<String, Object> collection = collectionLookup.get(collectionId);
+        if (collection != null) {
+            return new LinkedHashMap<>(collection);
+        }
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("id", collectionId);
+        response.put("name", null);
+        response.put("path", null);
+        response.put("group_id", null);
+        response.put("group_name", null);
+        return response;
+    }
+
+    private Map<Long, Map<String, Object>> buildCollectionLookup(CollectionTreeVO tree) {
+        Map<Long, Map<String, Object>> lookup = new LinkedHashMap<>();
+        for (CollectionGroupVO group : tree.getGroups()) {
+            addCollectionsToLookup(lookup, group, group.getCollections(), null);
+        }
+        return lookup;
+    }
+
+    private void addCollectionsToLookup(Map<Long, Map<String, Object>> lookup, CollectionGroupVO group,
+            List<CollectionVO> collections, String parentPath) {
+        for (CollectionVO collection : collections) {
+            String path = StringUtils.isBlank(parentPath) ? collection.getName() : parentPath + "/" + collection.getName();
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("id", collection.getId());
+            response.put("name", collection.getName());
+            response.put("path", path);
+            response.put("group_id", group.getId());
+            response.put("group_name", group.getName());
+            lookup.put(collection.getId(), response);
+
+            addCollectionsToLookup(lookup, group, collection.getChildren(), path);
+        }
+    }
+
+    private String buildAuthorSearchQuery(String displayName) {
+        if (StringUtils.isBlank(displayName)) {
+            return null;
+        }
+        return "author:\"" + displayName
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"") + "\"";
+    }
+}

--- a/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/ListCollectionContentTool.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/ListCollectionContentTool.java
@@ -1,0 +1,169 @@
+package com.huntly.server.mcp.tool;
+
+import com.huntly.interfaces.external.dto.PageItem;
+import com.huntly.interfaces.external.model.LibrarySaveStatus;
+import com.huntly.interfaces.external.query.PageListQuery;
+import com.huntly.interfaces.external.query.PageListSort;
+import com.huntly.server.connector.ConnectorType;
+import com.huntly.server.mcp.McpUtils;
+import com.huntly.server.service.PageListService;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * MCP Tool: list_collection_content - List content in a collection or Unsorted
+ */
+@Component
+public class ListCollectionContentTool implements McpTool {
+
+    private final PageListService pageListService;
+    private final McpUtils mcpUtils;
+
+    public ListCollectionContentTool(PageListService pageListService, McpUtils mcpUtils) {
+        this.pageListService = pageListService;
+        this.mcpUtils = mcpUtils;
+    }
+
+    @Override
+    public String getName() {
+        return "list_collection_content";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List content saved in a specific Huntly collection or in Unsorted. Use list_collections first to discover collection_id values. Use search_content with collection:\"Name With Spaces\" when you need keyword search within a collection; use this tool when you want to browse collection contents by saved order.";
+    }
+
+    @Override
+    public Map<String, Object> getInputSchema() {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("collection_id", Map.of(
+                "type", "integer",
+                "description", "Collection ID from list_collections. Required unless unsorted is true."
+        ));
+        properties.put("unsorted", Map.of(
+                "type", "boolean",
+                "default", false,
+                "description", "If true, list saved items that are not assigned to any collection. Do not combine with collection_id."
+        ));
+        properties.put("source_type", Map.of(
+                "type", "string",
+                "enum", List.of("all", "rss", "github", "tweet", "webpage"),
+                "default", "all",
+                "description", "Optional source filter."
+        ));
+        properties.put("start_date", Map.of(
+                "type", "string",
+                "description", "Start date filter (YYYY-MM-DD or ISO 8601). Uses collection time for collections and saved time for Unsorted."
+        ));
+        properties.put("end_date", Map.of(
+                "type", "string",
+                "description", "End date filter (YYYY-MM-DD or ISO 8601). Uses collection time for collections and saved time for Unsorted."
+        ));
+        properties.put("limit", Map.of(
+                "type", "integer",
+                "minimum", 1,
+                "maximum", 500,
+                "description", "Number of results to return, max 500"
+        ));
+        properties.put("title_only", Map.of(
+                "type", "boolean",
+                "default", false,
+                "description", "Return only compact fields to reduce token usage"
+        ));
+
+        schema.put("properties", properties);
+        return schema;
+    }
+
+    @Override
+    public Object execute(Map<String, Object> arguments) {
+        Long collectionId = getLongArg(arguments, "collection_id");
+        boolean unsorted = mcpUtils.getBoolArg(arguments, "unsorted", false);
+        String sourceType = mcpUtils.getStringArg(arguments, "source_type");
+        String startDate = mcpUtils.getStringArg(arguments, "start_date");
+        String endDate = mcpUtils.getStringArg(arguments, "end_date");
+        int limit = Math.min(Math.max(mcpUtils.getIntArg(arguments, "limit", 50), 1), 500);
+        boolean titleOnly = mcpUtils.getBoolArg(arguments, "title_only", false);
+
+        if (unsorted && collectionId != null) {
+            return Map.of("error", "Use either collection_id or unsorted, not both");
+        }
+        if (!unsorted && collectionId == null) {
+            return Map.of("error", "collection_id is required unless unsorted is true");
+        }
+
+        PageListQuery query = new PageListQuery();
+        query.setCount(limit);
+        query.setSaveStatus(LibrarySaveStatus.SAVED);
+        query.setIncludeArchived(true);
+
+        if (unsorted) {
+            query.setFilterUnsorted(true);
+            query.setSort(PageListSort.UNSORTED_SAVED_AT);
+        } else {
+            query.setCollectionId(collectionId);
+            query.setSort(PageListSort.COLLECTED_AT);
+        }
+
+        applySourceTypeFilter(query, sourceType);
+
+        if (startDate != null) {
+            query.setStartDate(startDate);
+        }
+        if (endDate != null) {
+            query.setEndDate(endDate);
+        }
+
+        List<PageItem> items = pageListService.getPageItems(query);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("count", items.size());
+        response.put("collection_id", collectionId);
+        response.put("unsorted", unsorted);
+        response.put("items", items.stream()
+                .map(item -> mcpUtils.toMcpPageItem(item, titleOnly))
+                .collect(Collectors.toList()));
+        return response;
+    }
+
+    private Long getLongArg(Map<String, Object> arguments, String key) {
+        Object value = arguments.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return Long.parseLong(value.toString());
+    }
+
+    private void applySourceTypeFilter(PageListQuery query, String sourceType) {
+        if (sourceType == null || "all".equals(sourceType)) {
+            return;
+        }
+        switch (sourceType) {
+            case "rss":
+                query.setConnectorType(ConnectorType.RSS.getCode());
+                break;
+            case "github":
+                query.setConnectorType(ConnectorType.GITHUB.getCode());
+                break;
+            case "tweet":
+                query.setContentFilterType(2);
+                break;
+            case "webpage":
+                query.setContentFilterType(1);
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/ListCollectionsTool.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/ListCollectionsTool.java
@@ -1,0 +1,83 @@
+package com.huntly.server.mcp.tool;
+
+import com.huntly.server.domain.vo.CollectionGroupVO;
+import com.huntly.server.domain.vo.CollectionTreeVO;
+import com.huntly.server.domain.vo.CollectionVO;
+import com.huntly.server.service.CollectionService;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * MCP Tool: list_collections - List collection tree for navigation
+ */
+@Component
+public class ListCollectionsTool implements McpTool {
+
+    private final CollectionService collectionService;
+
+    public ListCollectionsTool(CollectionService collectionService) {
+        this.collectionService = collectionService;
+    }
+
+    @Override
+    public String getName() {
+        return "list_collections";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List Huntly collection groups and collections with page counts. Use this to discover collection IDs before calling list_collection_content, or to find collection names for search_content queries like collection:\"Daily Reads\".";
+    }
+
+    @Override
+    public Map<String, Object> getInputSchema() {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("properties", new LinkedHashMap<>());
+        return schema;
+    }
+
+    @Override
+    public Object execute(Map<String, Object> arguments) {
+        CollectionTreeVO tree = collectionService.getTree();
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("unsorted_count", tree.getUnsortedCount());
+        response.put("groups", tree.getGroups().stream()
+                .map(this::toGroupResponse)
+                .collect(Collectors.toList()));
+        return response;
+    }
+
+    private Map<String, Object> toGroupResponse(CollectionGroupVO group) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("id", group.getId());
+        response.put("name", group.getName());
+        response.put("icon", group.getIcon());
+        response.put("color", group.getColor());
+        response.put("display_sequence", group.getDisplaySequence());
+        response.put("collections", group.getCollections().stream()
+                .map(this::toCollectionResponse)
+                .collect(Collectors.toList()));
+        return response;
+    }
+
+    private Map<String, Object> toCollectionResponse(CollectionVO collection) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("id", collection.getId());
+        response.put("group_id", collection.getGroupId());
+        response.put("parent_id", collection.getParentId());
+        response.put("name", collection.getName());
+        response.put("icon", collection.getIcon());
+        response.put("color", collection.getColor());
+        response.put("display_sequence", collection.getDisplaySequence());
+        response.put("page_count", collection.getPageCount());
+        response.put("children", collection.getChildren().stream()
+                .map(this::toCollectionResponse)
+                .collect(Collectors.toList()));
+        return response;
+    }
+}

--- a/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/SearchContentTool.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/SearchContentTool.java
@@ -34,7 +34,7 @@ public class SearchContentTool implements McpTool {
 
     @Override
     public String getDescription() {
-        return "Full-text search across all saved content in Huntly. Supports Chinese/English tokenization. IMPORTANT: Each result includes 'huntlyUrl' (Huntly's reading page) and 'url' (original source). When referencing content, prefer using huntlyUrl as the primary link.";
+        return "Full-text search across all saved content in Huntly. Use this when you have keywords, topics, authors, URLs, collection names, or date ranges and want relevance-ranked results. Supports Chinese/English tokenization and advanced syntax in query: url:{pattern}, author:{name}, collection:{name}. Wrap advanced values that contain spaces in quotes, for example collection:\"Daily Reads\" or author:\"Jane Doe\"; escape quotes inside quoted values with backslash. Use start_date/end_date with date_field for time filtering. Results are sorted by relevance, with title matches weighted higher than content matches. IMPORTANT: Each result includes 'huntlyUrl' (Huntly's reading page) and 'url' (original source). When referencing content, prefer using huntlyUrl as the primary link.";
     }
 
     @Override
@@ -45,7 +45,7 @@ public class SearchContentTool implements McpTool {
         Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("query", Map.of(
                 "type", "string",
-                "description", "Search keywords (required, cannot be empty). Supports advanced syntax combined with keywords: 'machine learning author:openai' or 'typescript url:github.com'. Note: Must include at least one search keyword; cannot use only advanced filters like 'author:xxx' alone."
+                "description", "Search keywords (required, cannot be empty). Supports advanced syntax: url:{pattern}, author:{name}, collection:{name}. Combine syntax with keywords, for example 'machine learning author:openai', 'typescript url:github.com', or 'notes collection:\"Daily Reads\"'. Wrap values containing spaces in double quotes, and escape quotes inside quoted values with backslash."
         ));
         properties.put("content_type", Map.of(
                 "type", "string",
@@ -54,8 +54,8 @@ public class SearchContentTool implements McpTool {
         ));
         properties.put("library_filter", Map.of(
                 "type", "string",
-                "enum", List.of("list", "starred", "archive", "later", "highlights"),
-                "description", "Filter by library status. list: saved to My List, starred: starred items, archive: archived items, later: read later items, highlights: items with highlights. If not specified, searches all content."
+                "enum", List.of("list", "starred", "archive", "later", "highlights", "unsorted"),
+                "description", "Filter by library status. list: saved to My List, starred: starred items, archive: archived items, later: read later items, highlights: items with highlights, unsorted: saved items not assigned to any collection. If not specified, searches all content."
         ));
         properties.put("search_title_only", Map.of(
                 "type", "boolean",
@@ -67,10 +67,31 @@ public class SearchContentTool implements McpTool {
                 "default", false,
                 "description", "If true, only return items that have been read."
         ));
+        properties.put("start_date", Map.of(
+                "type", "string",
+                "description", "Start date/time filter (YYYY-MM-DD or ISO 8601). Uses date_field to choose which indexed timestamp to filter."
+        ));
+        properties.put("end_date", Map.of(
+                "type", "string",
+                "description", "End date/time filter (YYYY-MM-DD or ISO 8601). Date-only values include the whole day."
+        ));
+        properties.put("date_field", Map.of(
+                "type", "string",
+                "enum", List.of("created_at", "collected_at", "last_read_at"),
+                "default", "created_at",
+                "description", "Timestamp field used by start_date/end_date. created_at: saved/fetched time, collected_at: collection assignment time, last_read_at: last read time."
+        ));
         properties.put("limit", Map.of(
                 "type", "integer",
+                "minimum", 1,
                 "maximum", 500,
                 "description", "Number of results to return, max 500"
+        ));
+        properties.put("page", Map.of(
+                "type", "integer",
+                "minimum", 1,
+                "default", 1,
+                "description", "Page number for search results, starting from 1. Use with limit to inspect additional pages."
         ));
         properties.put("title_only", Map.of(
                 "type", "boolean",
@@ -90,7 +111,11 @@ public class SearchContentTool implements McpTool {
         String libraryFilter = mcpUtils.getStringArg(arguments, "library_filter");
         boolean searchTitleOnly = mcpUtils.getBoolArg(arguments, "search_title_only", false);
         boolean alreadyRead = mcpUtils.getBoolArg(arguments, "already_read", false);
-        int limit = mcpUtils.getIntArg(arguments, "limit", 50);
+        String startDate = mcpUtils.getStringArg(arguments, "start_date");
+        String endDate = mcpUtils.getStringArg(arguments, "end_date");
+        String dateField = mcpUtils.getStringArg(arguments, "date_field");
+        int limit = Math.min(Math.max(mcpUtils.getIntArg(arguments, "limit", 50), 1), 500);
+        int page = Math.max(mcpUtils.getIntArg(arguments, "page", 1), 1);
         boolean titleOnly = mcpUtils.getBoolArg(arguments, "title_only", false);
 
         if (StringUtils.isBlank(query)) {
@@ -99,7 +124,15 @@ public class SearchContentTool implements McpTool {
 
         SearchQuery searchQuery = new SearchQuery();
         searchQuery.setQ(query);
-        searchQuery.setSize(Math.min(limit, 500));
+        searchQuery.setPage(page);
+        searchQuery.setSize(limit);
+        searchQuery.setContentType(contentType);
+        searchQuery.setLibraryFilter(libraryFilter);
+        searchQuery.setSearchTitleOnly(searchTitleOnly);
+        searchQuery.setAlreadyRead(alreadyRead);
+        searchQuery.setStartDate(startDate);
+        searchQuery.setEndDate(endDate);
+        searchQuery.setDateField(dateField);
 
         // Build query options from filter parameters
         String queryOptions = buildQueryOptions(contentType, libraryFilter, searchTitleOnly, alreadyRead);
@@ -109,14 +142,24 @@ public class SearchContentTool implements McpTool {
 
         PageSearchResult result = luceneService.searchPages(searchQuery);
 
-        return Map.of(
-                "total_hits", result.getTotalHits(),
-                "query", query,
-                "query_options", queryOptions != null ? queryOptions : "",
-                "items", result.getItems().stream()
-                        .map(item -> mcpUtils.toMcpPageItem(item, titleOnly))
-                        .collect(Collectors.toList())
-        );
+        long totalHits = result.getTotalHits();
+        int resultPage = result.getPage() != null ? result.getPage() : page;
+        long totalPages = totalHits == 0 ? 0 : (totalHits + limit - 1) / limit;
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("total_hits", totalHits);
+        response.put("page", resultPage);
+        response.put("page_size", limit);
+        response.put("total_pages", totalPages);
+        response.put("has_more", totalPages > resultPage);
+        response.put("cost_seconds", result.getCostSeconds());
+        response.put("query", query);
+        response.put("query_options", queryOptions != null ? queryOptions : "");
+        response.put("items", result.getItems().stream()
+                .map(item -> mcpUtils.toMcpPageItem(item, titleOnly))
+                .collect(Collectors.toList()));
+
+        return response;
     }
 
     /**

--- a/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/SearchContentTool.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/mcp/tool/SearchContentTool.java
@@ -4,6 +4,7 @@ import com.huntly.interfaces.external.dto.PageSearchResult;
 import com.huntly.interfaces.external.query.SearchQuery;
 import com.huntly.server.mcp.McpUtils;
 import com.huntly.server.service.LuceneService;
+import com.huntly.server.util.PageSizeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +19,10 @@ import java.util.stream.Collectors;
  */
 @Component
 public class SearchContentTool implements McpTool {
+
+    private static final int MAX_LIMIT = PageSizeUtils.MAX_PAGE_SIZE;
+    private static final int MAX_LUCENE_RESULT_WINDOW = 10_000;
+    private static final int MAX_PAGE = Math.max(1, MAX_LUCENE_RESULT_WINDOW / MAX_LIMIT);
 
     private final LuceneService luceneService;
     private final McpUtils mcpUtils;
@@ -84,14 +89,15 @@ public class SearchContentTool implements McpTool {
         properties.put("limit", Map.of(
                 "type", "integer",
                 "minimum", 1,
-                "maximum", 500,
+                "maximum", MAX_LIMIT,
                 "description", "Number of results to return, max 500"
         ));
         properties.put("page", Map.of(
                 "type", "integer",
                 "minimum", 1,
+                "maximum", MAX_PAGE,
                 "default", 1,
-                "description", "Page number for search results, starting from 1. Use with limit to inspect additional pages."
+                "description", "Page number for search results, starting from 1. Use with limit to inspect additional pages. Capped to " + MAX_PAGE + " so Lucene collection stays bounded when limit is at its maximum."
         ));
         properties.put("title_only", Map.of(
                 "type", "boolean",
@@ -114,8 +120,8 @@ public class SearchContentTool implements McpTool {
         String startDate = mcpUtils.getStringArg(arguments, "start_date");
         String endDate = mcpUtils.getStringArg(arguments, "end_date");
         String dateField = mcpUtils.getStringArg(arguments, "date_field");
-        int limit = Math.min(Math.max(mcpUtils.getIntArg(arguments, "limit", 50), 1), 500);
-        int page = Math.max(mcpUtils.getIntArg(arguments, "page", 1), 1);
+        int limit = Math.min(Math.max(mcpUtils.getIntArg(arguments, "limit", 50), 1), MAX_LIMIT);
+        int page = Math.min(Math.max(mcpUtils.getIntArg(arguments, "page", 1), 1), MAX_PAGE);
         boolean titleOnly = mcpUtils.getBoolArg(arguments, "title_only", false);
 
         if (StringUtils.isBlank(query)) {

--- a/app/server/huntly-server/src/main/java/com/huntly/server/service/LuceneService.java
+++ b/app/server/huntly-server/src/main/java/com/huntly/server/service/LuceneService.java
@@ -43,6 +43,12 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -303,7 +309,7 @@ public class LuceneService implements DisposableBean {
         List<PageItem> pageItems = new ArrayList<>();
         searchResult.setItems(pageItems);
         List<String> words = segmentWords(keyword, true);
-        SearchOption option = parseSearchOption(searchQuery.getQueryOptions());
+        SearchOption option = resolveSearchOption(searchQuery);
 
         try {
             Directory dir = getDirectory();
@@ -379,6 +385,11 @@ public class LuceneService implements DisposableBean {
                         if (query != null) {
                             boolQueryBuilder.add(query, BooleanClause.Occur.MUST);
                         }
+                    }
+
+                    Query dateRangeQuery = buildSearchDateRangeQuery(searchQuery);
+                    if (dateRangeQuery != null) {
+                        boolQueryBuilder.add(dateRangeQuery, BooleanClause.Occur.MUST);
                     }
 
                     for (AdvancedSearch advancedSearch : completeSearch.advancedSearches) {
@@ -546,42 +557,49 @@ public class LuceneService implements DisposableBean {
         return tokens;
     }
 
+    SearchOption resolveSearchOption(SearchQuery searchQuery) {
+        SearchOption option = parseSearchOption(searchQuery != null ? searchQuery.getQueryOptions() : null);
+        if (searchQuery == null) {
+            return option;
+        }
+
+        SearchOption.Type type = parseSearchType(searchQuery.getContentType());
+        if (type != null) {
+            option.setType(type);
+        }
+
+        SearchOption.Library library = parseLibraryFilter(searchQuery.getLibraryFilter());
+        if (library != null) {
+            option.setLibrary(library);
+        }
+
+        if (searchQuery.getAlreadyRead() != null) {
+            option.setAlreadyRead(searchQuery.getAlreadyRead());
+        }
+        if (searchQuery.getSearchTitleOnly() != null) {
+            option.setOnlySearchTitle(searchQuery.getSearchTitleOnly());
+        }
+        return option;
+    }
+
     private SearchOption parseSearchOption(String options) {
         SearchOption option = new SearchOption();
         if (StringUtils.isNotBlank(options)) {
             String[] keywords = options.split(",");
             for (String key : keywords) {
-                switch (key) {
-                    case "tweet":
-                        option.setType(SearchOption.Type.TWEET);
-                        break;
-                    case "github":
-                        option.setType(SearchOption.Type.GITHUB_STARRED_REPO);
-                        break;
-                    case "browser":
-                        option.setType(SearchOption.Type.BROWSER_HISTORY);
-                        break;
-                    case "feeds":
-                        option.setType(SearchOption.Type.FEEDS);
-                        break;
-                    case "highlights":
-                        option.setLibrary(SearchOption.Library.HIGHLIGHTS);
-                        break;
-                    case "list":
-                        option.setLibrary(SearchOption.Library.MY_LIST);
-                        break;
-                    case "starred":
-                        option.setLibrary(SearchOption.Library.STARRED);
-                        break;
-                    case "archive":
-                        option.setLibrary(SearchOption.Library.ARCHIVE);
-                        break;
-                    case "later":
-                        option.setLibrary(SearchOption.Library.READ_LATER);
-                        break;
-                    case "unsorted":
-                        option.setLibrary(SearchOption.Library.UNSORTED);
-                        break;
+                SearchOption.Type type = parseSearchType(key);
+                if (type != null) {
+                    option.setType(type);
+                    continue;
+                }
+
+                SearchOption.Library library = parseLibraryFilter(key);
+                if (library != null) {
+                    option.setLibrary(library);
+                    continue;
+                }
+
+                switch (StringUtils.lowerCase(StringUtils.trimToEmpty(key))) {
                     case "read":
                         option.setAlreadyRead(true);
                         break;
@@ -594,6 +612,108 @@ public class LuceneService implements DisposableBean {
             }
         }
         return option;
+    }
+
+    private SearchOption.Type parseSearchType(String contentType) {
+        switch (StringUtils.lowerCase(StringUtils.trimToEmpty(contentType))) {
+            case "tweet":
+                return SearchOption.Type.TWEET;
+            case "github":
+                return SearchOption.Type.GITHUB_STARRED_REPO;
+            case "browser":
+                return SearchOption.Type.BROWSER_HISTORY;
+            case "feeds":
+                return SearchOption.Type.FEEDS;
+            default:
+                return null;
+        }
+    }
+
+    private SearchOption.Library parseLibraryFilter(String libraryFilter) {
+        switch (StringUtils.lowerCase(StringUtils.trimToEmpty(libraryFilter))) {
+            case "highlights":
+                return SearchOption.Library.HIGHLIGHTS;
+            case "list":
+                return SearchOption.Library.MY_LIST;
+            case "starred":
+                return SearchOption.Library.STARRED;
+            case "archive":
+                return SearchOption.Library.ARCHIVE;
+            case "later":
+                return SearchOption.Library.READ_LATER;
+            case "unsorted":
+                return SearchOption.Library.UNSORTED;
+            default:
+                return null;
+        }
+    }
+
+    Query buildSearchDateRangeQuery(SearchQuery searchQuery) {
+        SearchDateRange dateRange = resolveSearchDateRange(searchQuery);
+        if (dateRange == null) {
+            return null;
+        }
+        if (dateRange.getEndEpochSecond() < dateRange.getStartEpochSecond()) {
+            return new MatchNoDocsQuery("Invalid search date range");
+        }
+        return LongPoint.newRangeQuery(dateRange.getDocField(), dateRange.getStartEpochSecond(), dateRange.getEndEpochSecond());
+    }
+
+    SearchDateRange resolveSearchDateRange(SearchQuery searchQuery) {
+        if (searchQuery == null || (StringUtils.isBlank(searchQuery.getStartDate()) && StringUtils.isBlank(searchQuery.getEndDate()))) {
+            return null;
+        }
+
+        Instant start = parseSearchDate(searchQuery.getStartDate(), 0);
+        Instant end = parseSearchDate(searchQuery.getEndDate(), 1);
+        long startEpochSecond = start != null ? start.getEpochSecond() : Long.MIN_VALUE;
+        long endEpochSecond = end != null ? end.getEpochSecond() - 1 : Long.MAX_VALUE;
+        return new SearchDateRange()
+                .setDocField(resolveSearchDateField(searchQuery.getDateField()))
+                .setStartEpochSecond(startEpochSecond)
+                .setEndEpochSecond(endEpochSecond);
+    }
+
+    private String resolveSearchDateField(String dateField) {
+        switch (StringUtils.lowerCase(StringUtils.trimToEmpty(dateField))) {
+            case "collected_at":
+            case "collectedat":
+            case "collected":
+                return DocFields.COLLECTED_AT;
+            case "last_read_at":
+            case "lastreadat":
+            case "read_at":
+            case "readat":
+            case "read":
+                return DocFields.LAST_READ_AT;
+            case "created_at":
+            case "createdat":
+            case "created":
+            default:
+                return DocFields.CREATED_AT;
+        }
+    }
+
+    private Instant parseSearchDate(String date, int plusDay) {
+        if (StringUtils.isBlank(date)) {
+            return null;
+        }
+        if (date.contains("T") || date.contains(":")) {
+            return parseSearchDateTime(date);
+        }
+        return LocalDate.parse(date).atStartOfDay(ZoneId.systemDefault()).toInstant().plus(plusDay, ChronoUnit.DAYS);
+    }
+
+    private Instant parseSearchDateTime(String dateTime) {
+        try {
+            return Instant.parse(dateTime);
+        } catch (DateTimeParseException e) {
+            try {
+                return OffsetDateTime.parse(dateTime).toInstant();
+            } catch (DateTimeParseException offsetException) {
+                return LocalDateTime.parse(dateTime).atZone(ZoneId.systemDefault()).toInstant();
+            }
+        }
     }
 
     private List<String> segmentWords(String keyword, boolean useSmart) {
@@ -650,5 +770,14 @@ public class LuceneService implements DisposableBean {
         private String docField;
         private String keyword;
         private List<String> words;
+    }
+
+    @Getter
+    @Setter
+    @Accessors(chain = true)
+    static class SearchDateRange {
+        private String docField;
+        private long startEpochSecond;
+        private long endEpochSecond;
     }
 }

--- a/app/server/huntly-server/src/test/java/com/huntly/server/mcp/CollectionMcpToolsTest.java
+++ b/app/server/huntly-server/src/test/java/com/huntly/server/mcp/CollectionMcpToolsTest.java
@@ -1,0 +1,134 @@
+package com.huntly.server.mcp;
+
+import com.huntly.interfaces.external.dto.PageItem;
+import com.huntly.interfaces.external.model.LibrarySaveStatus;
+import com.huntly.interfaces.external.query.PageListQuery;
+import com.huntly.interfaces.external.query.PageListSort;
+import com.huntly.server.domain.vo.CollectionGroupVO;
+import com.huntly.server.domain.vo.CollectionTreeVO;
+import com.huntly.server.domain.vo.CollectionVO;
+import com.huntly.server.mcp.tool.ListCollectionContentTool;
+import com.huntly.server.mcp.tool.ListCollectionsTool;
+import com.huntly.server.service.CollectionService;
+import com.huntly.server.service.PageListService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CollectionMcpToolsTest {
+
+    @Test
+    void listCollectionsReturnsAgentFriendlyTree() {
+        CollectionService collectionService = mock(CollectionService.class);
+        CollectionTreeVO tree = new CollectionTreeVO();
+        tree.setUnsortedCount(3L);
+
+        CollectionGroupVO group = new CollectionGroupVO();
+        group.setId(1L);
+        group.setName("Knowledge");
+        group.setDisplaySequence(2);
+
+        CollectionVO collection = new CollectionVO();
+        collection.setId(42L);
+        collection.setGroupId(1L);
+        collection.setName("Daily Reads");
+        collection.setPageCount(8L);
+        group.setCollections(List.of(collection));
+        tree.setGroups(List.of(group));
+
+        when(collectionService.getTree()).thenReturn(tree);
+
+        ListCollectionsTool tool = new ListCollectionsTool(collectionService);
+        Map<String, Object> response = asMap(tool.execute(Map.of()));
+
+        assertThat(response.get("unsorted_count")).isEqualTo(3L);
+        List<Map<String, Object>> groups = asMapList(response.get("groups"));
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0)).containsEntry("name", "Knowledge");
+
+        List<Map<String, Object>> collections = asMapList(groups.get(0).get("collections"));
+        assertThat(collections.get(0))
+                .containsEntry("id", 42L)
+                .containsEntry("name", "Daily Reads")
+                .containsEntry("page_count", 8L);
+    }
+
+    @Test
+    void listCollectionContentBuildsCollectionQuery() {
+        PageListService pageListService = mock(PageListService.class);
+        PageItem pageItem = new PageItem();
+        pageItem.setId(9L);
+        pageItem.setTitle("Collected item");
+        pageItem.setCollectionId(42L);
+        when(pageListService.getPageItems(any(PageListQuery.class))).thenReturn(List.of(pageItem));
+
+        ListCollectionContentTool tool = new ListCollectionContentTool(pageListService, new McpUtils());
+        Map<String, Object> response = asMap(tool.execute(Map.of(
+                "collection_id", 42,
+                "source_type", "tweet",
+                "limit", 10
+        )));
+
+        ArgumentCaptor<PageListQuery> queryCaptor = ArgumentCaptor.forClass(PageListQuery.class);
+        verify(pageListService).getPageItems(queryCaptor.capture());
+        PageListQuery query = queryCaptor.getValue();
+        assertThat(query.getCollectionId()).isEqualTo(42L);
+        assertThat(query.getFilterUnsorted()).isNull();
+        assertThat(query.getSort()).isEqualTo(PageListSort.COLLECTED_AT);
+        assertThat(query.getSaveStatus()).isEqualTo(LibrarySaveStatus.SAVED);
+        assertThat(query.getIncludeArchived()).isTrue();
+        assertThat(query.getContentFilterType()).isEqualTo(2);
+        assertThat(query.getCount()).isEqualTo(10);
+
+        assertThat(response.get("count")).isEqualTo(1);
+        assertThat(response.get("collection_id")).isEqualTo(42L);
+        assertThat(response.get("unsorted")).isEqualTo(false);
+    }
+
+    @Test
+    void listCollectionContentBuildsUnsortedQuery() {
+        PageListService pageListService = mock(PageListService.class);
+        when(pageListService.getPageItems(any(PageListQuery.class))).thenReturn(List.of());
+
+        ListCollectionContentTool tool = new ListCollectionContentTool(pageListService, new McpUtils());
+        tool.execute(Map.of("unsorted", true, "limit", 5));
+
+        ArgumentCaptor<PageListQuery> queryCaptor = ArgumentCaptor.forClass(PageListQuery.class);
+        verify(pageListService).getPageItems(queryCaptor.capture());
+        PageListQuery query = queryCaptor.getValue();
+        assertThat(query.getCollectionId()).isNull();
+        assertThat(query.getFilterUnsorted()).isTrue();
+        assertThat(query.getSort()).isEqualTo(PageListSort.UNSORTED_SAVED_AT);
+        assertThat(query.getCount()).isEqualTo(5);
+    }
+
+    @Test
+    void listCollectionContentRejectsAmbiguousTarget() {
+        ListCollectionContentTool tool = new ListCollectionContentTool(mock(PageListService.class), new McpUtils());
+
+        Map<String, Object> response = asMap(tool.execute(Map.of(
+                "collection_id", 42,
+                "unsorted", true
+        )));
+
+        assertThat(response.get("error")).isEqualTo("Use either collection_id or unsorted, not both");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> asMapList(Object value) {
+        return (List<Map<String, Object>>) value;
+    }
+}

--- a/app/server/huntly-server/src/test/java/com/huntly/server/mcp/GetXSaveRulesToolTest.java
+++ b/app/server/huntly-server/src/test/java/com/huntly/server/mcp/GetXSaveRulesToolTest.java
@@ -1,0 +1,126 @@
+package com.huntly.server.mcp;
+
+import com.huntly.server.domain.entity.TwitterUserSetting;
+import com.huntly.server.domain.vo.CollectionGroupVO;
+import com.huntly.server.domain.vo.CollectionTreeVO;
+import com.huntly.server.domain.vo.CollectionVO;
+import com.huntly.server.mcp.tool.GetXSaveRulesTool;
+import com.huntly.server.service.CollectionService;
+import com.huntly.server.service.TwitterUserSettingService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetXSaveRulesToolTest {
+
+    @Test
+    void returnsRulesWithOwnAccountsAndSaveDestinations() {
+        TwitterUserSettingService twitterUserSettingService = mock(TwitterUserSettingService.class);
+        CollectionService collectionService = mock(CollectionService.class);
+
+        CollectionTreeVO tree = new CollectionTreeVO();
+        CollectionGroupVO group = new CollectionGroupVO();
+        group.setId(1L);
+        group.setName("Knowledge");
+
+        CollectionVO parentCollection = new CollectionVO();
+        parentCollection.setId(10L);
+        parentCollection.setName("X");
+
+        CollectionVO childCollection = new CollectionVO();
+        childCollection.setId(42L);
+        childCollection.setName("Daily Reads");
+        childCollection.setParentId(10L);
+        parentCollection.setChildren(List.of(childCollection));
+
+        group.setCollections(List.of(parentCollection));
+        tree.setGroups(List.of(group));
+        when(collectionService.getTreeWithoutCounts()).thenReturn(tree);
+
+        TwitterUserSetting myAccount = new TwitterUserSetting();
+        myAccount.setId(7);
+        myAccount.setName("Jane Doe");
+        myAccount.setScreenName("jane");
+        myAccount.setMyself(true);
+        myAccount.setTweetToLibraryType(2);
+        myAccount.setBookmarkToCollectionId(42L);
+        myAccount.setLikeToLibraryType(4);
+
+        TwitterUserSetting otherAccount = new TwitterUserSetting();
+        otherAccount.setId(8);
+        otherAccount.setName("Open Source News");
+        otherAccount.setScreenName("oss_news");
+        otherAccount.setMyself(false);
+        otherAccount.setTweetToLibraryType(1);
+
+        when(twitterUserSettingService.getTwitterUserSettings()).thenReturn(List.of(myAccount, otherAccount));
+
+        GetXSaveRulesTool tool = new GetXSaveRulesTool(twitterUserSettingService, collectionService);
+        Map<String, Object> response = asMap(tool.execute(Map.of()));
+
+        assertThat(response.get("count")).isEqualTo(2);
+
+        List<Map<String, Object>> myAccounts = asMapList(response.get("my_accounts"));
+        assertThat(myAccounts).hasSize(1);
+        assertThat(myAccounts.get(0))
+                .containsEntry("display_name", "Jane Doe")
+                .containsEntry("screen_name", "jane")
+                .containsEntry("author_search_query", "author:\"Jane Doe\"");
+
+        List<Map<String, Object>> rules = asMapList(response.get("rules"));
+        Map<String, Object> rule = rules.get(0);
+        assertThat(rule)
+                .containsEntry("display_name", "Jane Doe")
+                .containsEntry("is_myself", true);
+
+        Map<String, Object> tweets = asMap(rule.get("tweets"));
+        assertThat(tweets)
+                .containsEntry("enabled", true)
+                .containsEntry("save_type", "starred")
+                .containsEntry("effective_save_type", "starred");
+
+        Map<String, Object> bookmarks = asMap(rule.get("bookmarks"));
+        assertThat(bookmarks)
+                .containsEntry("enabled", true)
+                .containsEntry("save_type", null)
+                .containsEntry("effective_save_type", "my_list");
+        assertThat(asMap(bookmarks.get("collection")))
+                .containsEntry("id", 42L)
+                .containsEntry("name", "Daily Reads")
+                .containsEntry("path", "X/Daily Reads")
+                .containsEntry("group_name", "Knowledge");
+
+        Map<String, Object> likes = asMap(rule.get("likes"));
+        assertThat(likes)
+                .containsEntry("save_type", "archive")
+                .containsEntry("effective_save_type", "archive");
+    }
+
+    @Test
+    void descriptionExplainsAuthorSearchUsage() {
+        GetXSaveRulesTool tool = new GetXSaveRulesTool(
+                mock(TwitterUserSettingService.class),
+                mock(CollectionService.class));
+
+        assertThat(tool.getName()).isEqualTo("get_x_save_rules");
+        assertThat(tool.getDescription())
+                .contains("is_myself=true")
+                .contains("author:\"Display Name\"")
+                .contains("screen_name only for X account identity");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> asMapList(Object value) {
+        return (List<Map<String, Object>>) value;
+    }
+}

--- a/app/server/huntly-server/src/test/java/com/huntly/server/mcp/McpServerControllerTest.java
+++ b/app/server/huntly-server/src/test/java/com/huntly/server/mcp/McpServerControllerTest.java
@@ -2,6 +2,7 @@ package com.huntly.server.mcp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.huntly.server.domain.entity.GlobalSetting;
+import com.huntly.server.mcp.tool.McpTool;
 import com.huntly.server.service.GlobalSettingService;
 import com.huntly.server.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class McpServerControllerTest {
@@ -30,11 +32,12 @@ class McpServerControllerTest {
     private static final String SESSION_ID = "session-1";
 
     private MockMvc mockMvc;
+    private McpToolRegistry toolRegistry;
     private UserService userService;
 
     @BeforeEach
     void setUp() {
-        McpToolRegistry toolRegistry = mock(McpToolRegistry.class);
+        toolRegistry = mock(McpToolRegistry.class);
         GlobalSettingService globalSettingService = mock(GlobalSettingService.class);
         userService = mock(UserService.class);
 
@@ -108,5 +111,39 @@ class McpServerControllerTest {
                 .andExpect(status().isUnauthorized());
 
         verify(userService, never()).existsByUsername("anonymousUser");
+    }
+
+    @Test
+    void testToolReturnsStructuredErrorWhenToolThrowsError() throws Exception {
+        when(toolRegistry.hasTool("broken_tool")).thenReturn(true);
+        when(toolRegistry.getTool("broken_tool")).thenReturn(new McpTool() {
+            @Override
+            public String getName() {
+                return "broken_tool";
+            }
+
+            @Override
+            public String getDescription() {
+                return "Broken test tool";
+            }
+
+            @Override
+            public Map<String, Object> getInputSchema() {
+                return Map.of("type", "object");
+            }
+
+            @Override
+            public Object execute(Map<String, Object> arguments) {
+                throw new AssertionError("simulated tool failure");
+            }
+        });
+
+        mockMvc.perform(post("/api/mcp/tools/test")
+                        .principal(() -> "huntly-user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"broken_tool\",\"arguments\":{}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error").value("Tool execution failed: simulated tool failure"));
     }
 }

--- a/app/server/huntly-server/src/test/java/com/huntly/server/mcp/McpUtilsTest.java
+++ b/app/server/huntly-server/src/test/java/com/huntly/server/mcp/McpUtilsTest.java
@@ -1,0 +1,30 @@
+package com.huntly.server.mcp;
+
+import com.huntly.interfaces.external.dto.PageItem;
+import com.huntly.server.mcp.dto.McpPageItem;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpUtilsTest {
+
+    @Test
+    void toMcpPageItemKeepsCollectionMetadataInTitleOnlyMode() {
+        Instant collectedAt = Instant.parse("2026-04-28T10:15:30Z");
+        PageItem pageItem = new PageItem();
+        pageItem.setId(11L);
+        pageItem.setTitle("Collected article");
+        pageItem.setUrl("https://example.com/article");
+        pageItem.setCollectionId(42L);
+        pageItem.setCollectedAt(collectedAt);
+
+        McpPageItem result = new McpUtils().toMcpPageItem(pageItem, true);
+
+        assertThat(result.getId()).isEqualTo(11L);
+        assertThat(result.getTitle()).isEqualTo("Collected article");
+        assertThat(result.getCollectionId()).isEqualTo(42L);
+        assertThat(result.getCollectedAt()).isEqualTo(collectedAt.toString());
+    }
+}

--- a/app/server/huntly-server/src/test/java/com/huntly/server/mcp/SearchContentToolTest.java
+++ b/app/server/huntly-server/src/test/java/com/huntly/server/mcp/SearchContentToolTest.java
@@ -1,0 +1,113 @@
+package com.huntly.server.mcp;
+
+import com.huntly.interfaces.external.dto.PageItem;
+import com.huntly.interfaces.external.dto.PageSearchResult;
+import com.huntly.interfaces.external.query.SearchQuery;
+import com.huntly.server.mcp.dto.McpPageItem;
+import com.huntly.server.mcp.tool.SearchContentTool;
+import com.huntly.server.service.LuceneService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SearchContentToolTest {
+
+    @Test
+    void inputSchemaDocumentsAdvancedSearchQuotingAndUnsortedPagination() {
+        SearchContentTool tool = new SearchContentTool(mock(LuceneService.class), new McpUtils());
+
+        Map<String, Object> schema = tool.getInputSchema();
+        Map<String, Object> properties = asMap(schema.get("properties"));
+        Map<String, Object> query = asMap(properties.get("query"));
+        Map<String, Object> libraryFilter = asMap(properties.get("library_filter"));
+        Map<String, Object> dateField = asMap(properties.get("date_field"));
+
+        assertThat(tool.getDescription())
+                .contains("collection:\"Daily Reads\"")
+                .contains("author:\"Jane Doe\"");
+        assertThat((String) query.get("description"))
+                .contains("collection:\"Daily Reads\"")
+                .contains("Wrap values containing spaces in double quotes");
+        assertThat(asList(libraryFilter.get("enum"))).contains("unsorted");
+        assertThat(properties).containsKeys("start_date", "end_date", "date_field");
+        assertThat(asList(dateField.get("enum"))).contains("created_at", "collected_at", "last_read_at");
+        assertThat(properties).containsKey("page");
+    }
+
+    @Test
+    void executeMapsFiltersAndReturnsPaginationMetadata() {
+        LuceneService luceneService = mock(LuceneService.class);
+        SearchContentTool tool = new SearchContentTool(luceneService, new McpUtils());
+        PageSearchResult searchResult = new PageSearchResult();
+        PageItem pageItem = new PageItem();
+        pageItem.setId(7L);
+        pageItem.setTitle("Search result");
+        searchResult.setItems(List.of(pageItem));
+        searchResult.setPage(2);
+        searchResult.setTotalHits(101);
+        searchResult.setCostSeconds(0.25);
+        when(luceneService.searchPages(any(SearchQuery.class))).thenReturn(searchResult);
+
+        Object rawResponse = tool.execute(Map.of(
+                "query", "machine learning",
+                "content_type", "feeds",
+                "library_filter", "unsorted",
+                "search_title_only", true,
+                "already_read", true,
+                "start_date", "2026-04-01",
+                "end_date", "2026-04-28",
+                "date_field", "collected_at",
+                "limit", 25,
+                "page", 2
+        ));
+
+        ArgumentCaptor<SearchQuery> queryCaptor = ArgumentCaptor.forClass(SearchQuery.class);
+        verify(luceneService).searchPages(queryCaptor.capture());
+        SearchQuery searchQuery = queryCaptor.getValue();
+        assertThat(searchQuery.getQ()).isEqualTo("machine learning");
+        assertThat(searchQuery.getSize()).isEqualTo(25);
+        assertThat(searchQuery.getPage()).isEqualTo(2);
+        assertThat(searchQuery.getContentType()).isEqualTo("feeds");
+        assertThat(searchQuery.getLibraryFilter()).isEqualTo("unsorted");
+        assertThat(searchQuery.getSearchTitleOnly()).isTrue();
+        assertThat(searchQuery.getAlreadyRead()).isTrue();
+        assertThat(searchQuery.getStartDate()).isEqualTo("2026-04-01");
+        assertThat(searchQuery.getEndDate()).isEqualTo("2026-04-28");
+        assertThat(searchQuery.getDateField()).isEqualTo("collected_at");
+        assertThat(searchQuery.getQueryOptions()).isEqualTo("feeds,unsorted,title,read");
+
+        Map<String, Object> response = asMap(rawResponse);
+        assertThat(response.get("total_hits")).isEqualTo(101L);
+        assertThat(response.get("page")).isEqualTo(2);
+        assertThat(response.get("page_size")).isEqualTo(25);
+        assertThat(response.get("total_pages")).isEqualTo(5L);
+        assertThat(response.get("has_more")).isEqualTo(true);
+        assertThat(response.get("cost_seconds")).isEqualTo(0.25);
+
+        List<McpPageItem> items = asPageItems(response.get("items"));
+        assertThat(items).extracting(McpPageItem::getId).containsExactly(7L);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> asList(Object value) {
+        return (List<String>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<McpPageItem> asPageItems(Object value) {
+        return (List<McpPageItem>) value;
+    }
+}

--- a/app/server/huntly-server/src/test/java/com/huntly/server/mcp/SearchContentToolTest.java
+++ b/app/server/huntly-server/src/test/java/com/huntly/server/mcp/SearchContentToolTest.java
@@ -29,6 +29,7 @@ class SearchContentToolTest {
         Map<String, Object> query = asMap(properties.get("query"));
         Map<String, Object> libraryFilter = asMap(properties.get("library_filter"));
         Map<String, Object> dateField = asMap(properties.get("date_field"));
+        Map<String, Object> page = asMap(properties.get("page"));
 
         assertThat(tool.getDescription())
                 .contains("collection:\"Daily Reads\"")
@@ -40,6 +41,7 @@ class SearchContentToolTest {
         assertThat(properties).containsKeys("start_date", "end_date", "date_field");
         assertThat(asList(dateField.get("enum"))).contains("created_at", "collected_at", "last_read_at");
         assertThat(properties).containsKey("page");
+        assertThat(page.get("maximum")).isEqualTo(20);
     }
 
     @Test
@@ -94,6 +96,31 @@ class SearchContentToolTest {
 
         List<McpPageItem> items = asPageItems(response.get("items"));
         assertThat(items).extracting(McpPageItem::getId).containsExactly(7L);
+    }
+
+    @Test
+    void executeClampsPageToSafeMaximumForLuceneCollection() {
+        LuceneService luceneService = mock(LuceneService.class);
+        SearchContentTool tool = new SearchContentTool(luceneService, new McpUtils());
+        PageSearchResult searchResult = new PageSearchResult();
+        searchResult.setItems(List.of());
+        when(luceneService.searchPages(any(SearchQuery.class))).thenReturn(searchResult);
+
+        Object rawResponse = tool.execute(Map.of(
+                "query", "machine learning",
+                "limit", 500,
+                "page", Integer.MAX_VALUE
+        ));
+
+        ArgumentCaptor<SearchQuery> queryCaptor = ArgumentCaptor.forClass(SearchQuery.class);
+        verify(luceneService).searchPages(queryCaptor.capture());
+        SearchQuery searchQuery = queryCaptor.getValue();
+        assertThat(searchQuery.getSize()).isEqualTo(500);
+        assertThat(searchQuery.getPage()).isEqualTo(20);
+
+        Map<String, Object> response = asMap(rawResponse);
+        assertThat(response.get("page")).isEqualTo(20);
+        assertThat(response.get("page_size")).isEqualTo(500);
     }
 
     @SuppressWarnings("unchecked")

--- a/app/server/huntly-server/src/test/java/com/huntly/server/service/LuceneServiceSearchSyntaxTest.java
+++ b/app/server/huntly-server/src/test/java/com/huntly/server/service/LuceneServiceSearchSyntaxTest.java
@@ -1,11 +1,15 @@
 package com.huntly.server.service;
 
 import com.huntly.server.config.HuntlyProperties;
+import com.huntly.server.domain.constant.DocFields;
 import com.huntly.server.domain.entity.Collection;
 import com.huntly.server.repository.CollectionRepository;
 import com.huntly.server.repository.PageRepository;
+import com.huntly.interfaces.external.model.SearchOption;
+import com.huntly.interfaces.external.query.SearchQuery;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,5 +58,48 @@ class LuceneServiceSearchSyntaxTest {
 
         assertThat(completeSearch.getKeyword()).isEqualTo("machine");
         assertThat(completeSearch.getCollectionIds()).containsExactly(42L);
+    }
+
+    @Test
+    void resolveSearchOption_prefersStructuredSearchQueryFields() {
+        LuceneService luceneService = new LuceneService(
+                mock(PageRepository.class),
+                mock(PageListService.class),
+                new HuntlyProperties(),
+                mock(CollectionRepository.class)
+        );
+        SearchQuery searchQuery = new SearchQuery();
+        searchQuery.setQueryOptions("tweet,starred");
+        searchQuery.setContentType("feeds");
+        searchQuery.setLibraryFilter("unsorted");
+        searchQuery.setSearchTitleOnly(true);
+        searchQuery.setAlreadyRead(true);
+
+        SearchOption option = luceneService.resolveSearchOption(searchQuery);
+
+        assertThat(option.getType()).isEqualTo(SearchOption.Type.FEEDS);
+        assertThat(option.getLibrary()).isEqualTo(SearchOption.Library.UNSORTED);
+        assertThat(option.getOnlySearchTitle()).isTrue();
+        assertThat(option.getAlreadyRead()).isTrue();
+    }
+
+    @Test
+    void resolveSearchDateRange_usesStructuredDateFilterFields() {
+        LuceneService luceneService = new LuceneService(
+                mock(PageRepository.class),
+                mock(PageListService.class),
+                new HuntlyProperties(),
+                mock(CollectionRepository.class)
+        );
+        SearchQuery searchQuery = new SearchQuery();
+        searchQuery.setStartDate("2026-04-01T00:00:00Z");
+        searchQuery.setEndDate("2026-04-02T00:00:00Z");
+        searchQuery.setDateField("collected_at");
+
+        LuceneService.SearchDateRange dateRange = luceneService.resolveSearchDateRange(searchQuery);
+
+        assertThat(dateRange.getDocField()).isEqualTo(DocFields.COLLECTED_AT);
+        assertThat(dateRange.getStartEpochSecond()).isEqualTo(Instant.parse("2026-04-01T00:00:00Z").getEpochSecond());
+        assertThat(dateRange.getEndEpochSecond()).isEqualTo(Instant.parse("2026-04-02T00:00:00Z").getEpochSecond() - 1);
     }
 }


### PR DESCRIPTION
## Summary

- **Server – MCP search enhancements**: add `start_date`/`end_date`/`date_field` date-range filtering and pagination (`page` parameter) to `SearchContentTool`; expose `collectionId`/`collectedAt` in all `McpPageItem` builder paths; add structured filter fields (`contentType`, `libraryFilter`, `alreadyRead`, `searchTitleOnly`) directly to `SearchQuery` instead of relying on the legacy `queryOptions` string; refactor `McpServerController` tool dispatch with `getToolArguments`/`executeTool` helpers; refactor `LuceneService` search-option resolution and add `buildSearchDateRangeQuery`
- **Server – new MCP tools**: `ListCollections`, `ListCollectionContent`, `GetXSaveRules`
- **Extension – agent tools**: add `AbortSignal` support to `createAgentToolContext` and MCP client loading so in-flight requests are cancelled when the user stops a chat; add `getCurrentTimeTool` for time-aware AI responses; add retry button (`RotateCcw`) to `UserMessage`; increase agent tool loop max steps from 5 → 50
- **Client – i18n**: translate document titles and nav labels in all settings pages and `PageList` so they update correctly on language switch

## Test plan

- [ ] Server: `./mvnw test` in `huntly-server` — new unit tests in `SearchContentToolTest`, `CollectionMcpToolsTest`, `GetXSaveRulesToolTest`, `McpUtilsTest`, `LuceneServiceSearchSyntaxTest`, `McpServerControllerTest` all pass
- [ ] Extension: `yarn test` in `app/extension` — `agentToolsAbort.test.ts` and `UserMessage.test.tsx` pass
- [ ] Manual: verify MCP search with `start_date`/`end_date` returns only items in range
- [ ] Manual: verify aborting a chat cancels MCP SSE connections (no dangling requests)
- [ ] Manual: switch UI language and confirm settings page titles and nav labels update immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)